### PR TITLE
Irc.Bot rename.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Todo:
 
 #### A simple and low-boilerplate framework to build IRC bots.
 ~~~javascript
-var bot = new IRC.Bot('irc.freenode.net', 6667, 'prawnsbot');
+var bot = new IRC.Client('irc.freenode.net', 6667, 'prawnsbot');
 bot.connect();
 
 bot.on('privmsg', function(event) {
@@ -41,7 +41,7 @@ bot.on('privmsg', function(event) {
 
 #### A more fleshed out framework for clients
 ~~~javascript
-var bot = new IRC.Bot('irc.freenode.net', 6667, 'prawnsbot');
+var bot = new IRC.Client('irc.freenode.net', 6667, 'prawnsbot');
 bot.connect();
 
 var buffers = [];

--- a/examples/bot.js
+++ b/examples/bot.js
@@ -1,6 +1,6 @@
 var IRC = require('../');
 
-var bot = new IRC.Client('5.39.86.47', 6667, false, 'prawnsbot', 'prawnsbot', {});
+var bot = new IRC.Client('irc.freenode.net', 6667, false, 'prawnsbot', 'prawnsbot', {});
 bot.connect();
 bot.on('registered', function() {
 	console.log('Connected!');

--- a/examples/bot.js
+++ b/examples/bot.js
@@ -1,6 +1,6 @@
 var IRC = require('../');
 
-var bot = new IRC.Bot('5.39.86.47', 6667, false, 'prawnsbot', 'prawnsbot', {});
+var bot = new IRC.Client('5.39.86.47', 6667, false, 'prawnsbot', 'prawnsbot', {});
 bot.connect();
 bot.on('registered', function() {
 	console.log('Connected!');

--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-module.exports.Bot = require('./src/bot');
+module.exports.Client = require('./src/client');
 module.exports.ircLineParser = require('./src/ircLineParser');


### PR DESCRIPTION
Change `IrcBot` (and related) to `IrcClient` as well as `Irc.Bot(...)` to `Irc.Client(...)`.
Change the address in `examples/bot.js` to `irc.freenode.net`, matching the README.