### PR TITLE
Another middleware method

### DIFF
--- a/examples/bot.js
+++ b/examples/bot.js
@@ -5,34 +5,52 @@ var IRC = require('../');
  * Example middleware structure to handle NickServ authentication
  * Accepts a `nickserv` object from the client connect() options
  */
-function NickservMiddleware(command, event, client, next) {
-	if (command === '005') {
-		if (client.options.nickserv) {
-			var options = client.options.nickserv;
-			client.say('nickserv', 'identify ' + options.account + ' ' + options.password);
+function NickservMiddleware() {
+	return function(client, raw_events, parsed_events) {
+		raw_events.use(theMiddleware);
+	}
+
+
+	function theMiddleware(command, event, client, next) {
+		if (command === '005') {
+			if (client.options.nickserv) {
+				var options = client.options.nickserv;
+				client.say('nickserv', 'identify ' + options.account + ' ' + options.password);
+			}
 		}
-	}
 
-	if (command === 'PRIVMSG' && event.params[0].toLowerCase() === 'nickserv') {
-		// Handle success/retries/failures
-	}
+		if (command === 'PRIVMSG' && event.params[0].toLowerCase() === 'nickserv') {
+			// Handle success/retries/failures
+		}
 
-	next();
+		next();
+	}
 }
 
 
 
-function MyIrcMiddleware(command, event, client, next) {
-	console.log('[MyMiddleware]', command, event);
-	if (command === 'PRIVMSG' && event.params[1].indexOf('omg') === 0) {
-		event.params[1] += '!!!!!';
+function MyIrcMiddleware() {
+	return function(client, raw_events, parsed_events) {
+		parsed_events.use(theMiddleware);
 	}
-	next();
+
+
+	function theMiddleware(command, event, client, next) {
+		console.log('[MyMiddleware]', command, event);
+		if (command === 'message' && event.msg.indexOf('omg') === 0) {
+			event.msg += '!!!!!';
+			event.reply('> appended extra points');
+		}
+
+		next();
+	}
 }
+
+
 
 
 var bot = new IRC.Client();
-bot.use(MyIrcMiddleware);
+bot.use(MyIrcMiddleware());
 bot.connect({
 	host: 'irc.snoonet.org',
 	nick: 'prawnsbot'

--- a/examples/bot.js
+++ b/examples/bot.js
@@ -32,11 +32,12 @@ function NickservMiddleware() {
 function MyIrcMiddleware() {
 	return function(client, raw_events, parsed_events) {
 		parsed_events.use(theMiddleware);
+		client.requestCap('kiwiirc.com/user');
 	}
 
 
 	function theMiddleware(command, event, client, next) {
-		console.log('[MyMiddleware]', command, event);
+		//console.log('[MyMiddleware]', command, event);
 		if (command === 'message' && event.msg.indexOf('omg') === 0) {
 			event.msg += '!!!!!';
 			event.reply('> appended extra points');

--- a/examples/bot.js
+++ b/examples/bot.js
@@ -1,8 +1,40 @@
 var IRC = require('../');
 
+
+/**
+ * Example middleware structure to handle NickServ authentication
+ * Accepts a `nickserv` object from the client connect() options
+ */
+function NickservMiddleware(command, event, client, next) {
+	if (command === '005') {
+		if (client.options.nickserv) {
+			var options = client.options.nickserv;
+			client.say('nickserv', 'identify ' + options.account + ' ' + options.password);
+		}
+	}
+
+	if (command === 'PRIVMSG' && event.params[0].toLowerCase() === 'nickserv') {
+		// Handle success/retries/failures
+	}
+
+	next();
+}
+
+
+
+function MyIrcMiddleware(command, event, client, next) {
+	console.log('[MyMiddleware]', command, event);
+	if (command === 'PRIVMSG' && event.params[1].indexOf('omg') === 0) {
+		event.params[1] += '!!!!!';
+	}
+	next();
+}
+
+
 var bot = new IRC.Client();
+bot.use(MyIrcMiddleware);
 bot.connect({
-	host: '5.39.86.47',
+	host: 'irc.snoonet.org',
 	nick: 'prawnsbot'
 });
 bot.on('registered', function() {
@@ -20,11 +52,10 @@ bot.on('close', function() {
 	console.log('Connection close');
 });
 
-bot.on('privmsg', function(event) {
+bot.on('message', function(event) {
+	console.log('<' + event.target + '>', event.msg);
 	if (event.msg.indexOf('whois') === 0) {
 		bot.whois(event.msg.split(' ')[1]);
-	} else {
-		event.reply('no');
 	}
 });
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "es6-set": "^0.1.3",
     "iconv-lite": "^0.4.11",
     "lodash": "^3.10.1",
-    "socksjs": "^0.5.0"
+    "socksjs": "^0.5.0",
+    "middleware-handler": "^0.2.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/src/client.js
+++ b/src/client.js
@@ -86,6 +86,7 @@ IrcClient.prototype.connect = function(options) {
         .pipe(new MiddlewareStream(this.raw_middleware, this))
         .pipe(this.command_handler);
 
+    // Proxy the command handler events onto the client object, with some added sugar
     this.proxyIrcEvents();
 
     // Everything is setup and prepared, start connecting
@@ -93,7 +94,8 @@ IrcClient.prototype.connect = function(options) {
 };
 
 
-// Parsed events from the command handler are handled in order:
+// Proxy the command handler events onto the client object, with some added sugar
+// Events are handled in order:
 // 1. Received from the command handler
 // 2. Checked if any extra properties/methods are to be added to the event + re-emitted
 // 3. Routed through middleware

--- a/src/client.js
+++ b/src/client.js
@@ -80,7 +80,7 @@ IrcClient.prototype.connect = function(options) {
 
     // IRC command routing
     this.connection
-        .pipe(new MiddlewareStream(this.middleware))
+        .pipe(new MiddlewareStream(this.middleware, this))
         .pipe(this.command_handler);
 
     // Everything is setup and prepared, start connecting

--- a/src/client.js
+++ b/src/client.js
@@ -15,6 +15,8 @@ function IrcClient() {
     // Provides middleware hooks for either raw IRC commands or the easier to use parsed commands
     this.raw_middleware = new MiddlewareHandler();
     this.parsed_middleware = new MiddlewareHandler();
+
+    this.request_extra_caps = [];
 }
 
 util.inherits(IrcClient, EventEmitter);
@@ -40,6 +42,11 @@ IrcClient.prototype._applyDefaultOptions = function(user_options) {
 };
 
 
+IrcClient.prototype.requestCap = function(cap) {
+    this.request_extra_caps = this.request_extra_caps.concat(cap);
+};
+
+
 IrcClient.prototype.use = function(middleware_fn) {
     middleware_fn(this, this.raw_middleware, this.parsed_middleware);
     return this;
@@ -60,12 +67,14 @@ IrcClient.prototype.connect = function(options) {
 
     this.connection = new Connection(options);
     this.network = new NetworkInfo();
-    this.command_handler = new Commands.Handler(this.connection, this.network);
     this.user = new User({
         nick: options.nick,
         username: options.username,
         gecos: options.gecos
     });
+
+    this.command_handler = new Commands.Handler(this.connection, this.network);
+    this.command_handler.requestExtraCaps(this.request_extra_caps);
 
     client.addCommandHandlerListeners();
     

--- a/src/commands.js
+++ b/src/commands.js
@@ -14,6 +14,8 @@ function IrcCommandsHandler (connection, network_info) {
     this.network = network_info;
     this.handlers = [];
 
+    this.request_extra_caps = [];
+
     require('./commands/registration')(this);
     require('./commands/channel')(this);
     require('./commands/user')(this);
@@ -41,6 +43,11 @@ IrcCommandsHandler.prototype.dispatch = function (irc_command) {
     } else {
         this.emitUnknownCommand(irc_command);
     }
+};
+
+
+IrcCommandsHandler.prototype.requestExtraCaps = function(cap) {
+    this.request_extra_caps = this.request_extra_caps.concat(cap);
 };
 
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -7,6 +7,9 @@ var _ = require('lodash'),
 function IrcCommandsHandler (connection, network_info) {
     stream.Writable.call(this, { objectMode : true });
 
+    // Adds an 'all' event to .emit()
+    this.addAllEventName();
+
     this.connection = connection;
     this.network = network_info;
     this.handlers = [];
@@ -75,9 +78,14 @@ IrcCommandsHandler.prototype.emitGenericNotice = function (command, msg, is_erro
 };
 
 
-IrcCommandsHandler.prototype.emit = function() {
-    this.connection.emit.apply(this.connection, ['all'].concat(Array.prototype.slice.call(arguments,0)));
-    this.connection.emit.apply(this.connection, arguments);
+// Adds an 'all' event to .emit()
+IrcCommandsHandler.prototype.addAllEventName = function() {
+    var original_emit = this.emit;
+    this.emit = function() {
+        var args = Array.prototype.slice.call(arguments, 0);
+        original_emit.apply(this, ['all'].concat(args));
+        original_emit.apply(this, args);
+    };
 };
 
 

--- a/src/commands/registration.js
+++ b/src/commands/registration.js
@@ -59,6 +59,10 @@ var handlers = {
 
         // Which capabilities we want to enable
         var want = ['multi-prefix', 'away-notify', 'server-time', 'extended-join', 'znc.in/server-time-iso', 'znc.in/server-time', 'twitch.tv/membership'];
+        want = _(want)
+            .concat(this.request_extra_caps)
+            .uniq()
+            .value();
 
         if (this.connection.password) {
             want.push('sasl');

--- a/src/middlewarestream.js
+++ b/src/middlewarestream.js
@@ -1,0 +1,52 @@
+var util            = require('util'),
+    DuplexStream    = require('stream').Duplex;
+
+module.exports = MiddlwareStream;
+
+/**
+ * Taking a middlware object and its associated client, create a stream to
+ * pipe events into the middleware and spit them back out once completed.
+ */
+
+function MiddlwareStream(middleware_handler, client) {
+    DuplexStream.call(this, { objectMode : true });
+    this.middleware = middleware_handler;
+    this.client = client;
+    this.buffer = [];
+    this._reading = false;
+}
+
+util.inherits(MiddlwareStream, DuplexStream);
+
+
+
+MiddlwareStream.prototype._write = function(chunk, encoding, callback) {
+    var that = this;
+
+    this.middleware.handle([chunk.command, chunk, this.client], function(err) {
+        if (err) {
+            console.error('Middleware error', err);
+            return;
+        }
+
+        that.buffer.push(chunk);
+        if (that._reading) {
+            that._read();
+        }
+    });
+
+    callback();
+};
+
+MiddlwareStream.prototype._read = function() {
+    var message;
+
+    this._reading = true;
+
+    while (this.buffer.length > 0) {
+        message = this.buffer.shift();
+        if (!this.push(message)) {
+            this._reading = false;
+        }
+    }
+};

--- a/src/middlewarestream.js
+++ b/src/middlewarestream.js
@@ -1,14 +1,14 @@
 var util            = require('util'),
     DuplexStream    = require('stream').Duplex;
 
-module.exports = MiddlwareStream;
+module.exports = MiddlewareStream;
 
 /**
  * Taking a middlware object and its associated client, create a stream to
  * pipe events into the middleware and spit them back out once completed.
  */
 
-function MiddlwareStream(middleware_handler, client) {
+function MiddlewareStream(middleware_handler, client) {
     DuplexStream.call(this, { objectMode : true });
     this.middleware = middleware_handler;
     this.client = client;
@@ -16,11 +16,11 @@ function MiddlwareStream(middleware_handler, client) {
     this._reading = false;
 }
 
-util.inherits(MiddlwareStream, DuplexStream);
+util.inherits(MiddlewareStream, DuplexStream);
 
 
 
-MiddlwareStream.prototype._write = function(chunk, encoding, callback) {
+MiddlewareStream.prototype._write = function(chunk, encoding, callback) {
     var that = this;
 
     this.middleware.handle([chunk.command, chunk, this.client], function(err) {
@@ -38,7 +38,7 @@ MiddlwareStream.prototype._write = function(chunk, encoding, callback) {
     callback();
 };
 
-MiddlwareStream.prototype._read = function() {
+MiddlewareStream.prototype._read = function() {
     var message;
 
     this._reading = true;


### PR DESCRIPTION
Aims:
* Clean way of piping commands from connection > middleware > command handler.
* Let middleware deal with core IRC events and modify them as needed.

Requires thinking:
* Only allowing middleware process raw IRC events is tedious. Perhaps a way to process either raw events or our processed commands.
* Baring in mind that the command handlers need to be very fast, do we put them in a "irc-framework" middleware, a middleware for each group (messaging/registration/etc) or leave them as is for performance?