### PR TITLE
Fix calling `arguments.slice` in CTCP code

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -275,7 +275,7 @@ IrcClient.prototype.part = function(channel, message) {
 
 
 IrcClient.prototype.ctcpRequest = function(target, type /*, paramN*/) {
-    var params = arguments.slice(2);
+    var params = Array.prototype.slice.call(arguments, 2);
     this.raw(
         'PRIVMSG',
         target,
@@ -286,7 +286,7 @@ IrcClient.prototype.ctcpRequest = function(target, type /*, paramN*/) {
 
 
 IrcClient.prototype.ctcpResponse = function(target, type /*, paramN*/) {
-    var params = arguments.slice(2);
+    var params = Array.prototype.slice.call(arguments, 2);
     this.raw(
         'NOTICE',
         target,


### PR DESCRIPTION
I was testing our irc-framework branch at The Lounge and crashed the client by sending a CTCP PING to it. This causes us to call `irc.ctcpResponse(data.nick, "PING " + split[1]);` which result in the following crash:

```
./lounge/node_modules/irc-framework/src/client.js:289
    var params = arguments.slice(2);
                           ^

TypeError: arguments.slice is not a function
    at IrcClient.ctcpResponse (./lounge/node_modules/irc-framework/src/client.js:289:28)
    at IrcClient.<anonymous> (./lounge/src/plugins/irc-events/ctcp.js:12:9)
    at emitOne (events.js:90:13)
```

A quick grep on the whole source shows this is the only occurrence and the others already use `Array.prototype.slice.call(arguments, n)`.