### PR TITLE
Use correct variable when client's nick changes

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -320,7 +320,7 @@ Also triggers a **message** event with .type = 'privmsg'
     nick: 'prawnsalad',
     ident: 'prawn',
     hostname: 'isp.manchester.net',
-    newnick: 'prawns_new_nick',
+    new_nick: 'prawns_new_nick',
     time: 000000000
 }
 ~~~

--- a/src/commands/handlers/user.js
+++ b/src/commands/handlers/user.js
@@ -11,7 +11,7 @@ var handlers = {
             nick: command.nick,
             ident: command.ident,
             hostname: command.hostname,
-            newnick: command.params[0],
+            new_nick: command.params[0],
             time: time
         });
     },


### PR DESCRIPTION
Fixes a bug when `irc.user.nick` becomes undefined after a nick change.