### PR TITLE
Fix getting localAddress from the wrong object

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -65,7 +65,7 @@ Connection.prototype.connect = function() {
     }
 
     getConnectionFamily(dest_addr, function getConnectionFamilyCb(err, family, host) {
-        var outgoing_addr = this.localAddress || '0.0.0.0';
+        var outgoing_addr = that.localAddress || '0.0.0.0';
         var ircd_host = host;
         var ircd_port = options.port || 6667;
 


### PR DESCRIPTION
Fixes a slight `this` instead of `that` in a closure mistake that made the `localAddress` option not work at all :)