### PR TITLE
Add option to ping the server periodically

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -28,7 +28,9 @@ IrcClient.prototype._applyDefaultOptions = function(user_options) {
         nick: 'ircbot',
         username: 'ircbot',
         gecos: 'ircbot',
-        encoding: 'utf8'
+        encoding: 'utf8',
+        ping_interval: 30,
+        ping_timeout: 120,
     };
 
     var props = Object.keys(defaults);
@@ -87,6 +89,7 @@ IrcClient.prototype.connect = function(options) {
     this.connection.on('socket connected', function() {
         client.emit('socket connected');
         client.registerToNetwork();
+        client.startPeriodicPing();
     });
 
     // IRC command routing
@@ -112,6 +115,8 @@ IrcClient.prototype.proxyIrcEvents = function() {
     var client = this;
 
     this.command_handler.on('all', function(event_name, event_arg) {
+        client.resetPingTimer();
+        
         // Add a reply() function to selected message events
         if (['privmsg', 'notice', 'action'].indexOf(event_name) > -1) {
             event_arg.reply = function(message) {
@@ -179,6 +184,49 @@ IrcClient.prototype.registerToNetwork = function() {
 };
 
 
+IrcClient.prototype.startPeriodicPing = function() {
+    var that = this;
+    var ping_timer = null;
+    var timeout_timer = null;
+    
+    if(that.options.ping_interval <= 0 || that.options.ping_timeout <= 0) {
+        return;
+    }
+    
+    function scheduleNextPing() {
+        ping_timer = that.connection.setTimeout(pingServer, that.options.ping_interval*1000);
+    }
+    
+    function resetPingTimer() {
+        if(ping_timer) {
+            that.connection.clearTimeout(ping_timer);
+        }
+        
+        if(timeout_timer) {
+            that.connection.clearTimeout(timeout_timer);
+        }
+        
+        scheduleNextPing();
+    }
+    
+    function pingServer() {
+        timeout_timer = that.connection.setTimeout(pingTimeout, that.options.ping_timeout*1000);
+        that.ping();
+    }
+    
+    function pingTimeout() {
+        that.emit('ping timeout');
+        that.quit('Ping timeout (' + that.options.ping_timeout + ' seconds)');
+    }
+    
+    this.resetPingTimer = resetPingTimer;
+    scheduleNextPing();
+};
+
+
+IrcClient.prototype.resetPingTimer = function() {};
+
+
 Object.defineProperty(IrcClient.prototype, 'connected', {
     enumerable: true,
     get: function() {
@@ -220,6 +268,11 @@ IrcClient.prototype.rawString = function(input) {
 
 IrcClient.prototype.quit = function(message) {
     this.connection.end(this.rawString('QUIT', message));
+};
+
+
+IrcClient.prototype.ping = function(message) {
+    this.raw('PING', message || '*');
 };
 
 

--- a/src/commands/handlers/misc.js
+++ b/src/commands/handlers/misc.js
@@ -80,6 +80,13 @@ var handlers = {
     },
 
 
+    PONG: function(command) {
+        this.emit('pong', {
+            message: command.params[1]
+        });
+    },
+
+
     MODE: function(command) {
         // Check if we have a server-time
         var time = command.getServerTime();


### PR DESCRIPTION
**NOTE: Depends on #36**

This adds two config options, `pingInterval` and `pingTimeout`, that when set makes the framework periodically send `PING` commands to the server in order to check that the connection is still alive and not stuck (see [#255 on The Lounge](https://github.com/thelounge/lounge/issues/255)).

Quick test script:

```javascript
var IRC = require("./");
var client = new IRC.Client();

client.on("disconnect", function() {
	console.log("disconnected");
});

client.on("ping timeout", function() {
	console.log("ping timeout");
});

client.connect({
	host: "irc.example.net",
	port: 6667,
	nick: "irc-framework",
	pingInterval: 10,
	pingTimeout: 10,
});
```

These iptables rules will simulate a gone server: `iptables -A INPUT -s irc.example.net -j DROP` and `iptables -A OUTPUT -d irc.example.net -j DROP`.

I'm not exactly sure about the `that.quit('Ping timeout (' + that.options.pingTimeout*1000 + ' seconds)');` part as I don't know how exactly errors needs to be reported.