### PR TITLE
Fix sending messages starting with :

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -264,7 +264,7 @@ IrcClient.prototype.rawString = function(input) {
         return (typeof item === 'number' || typeof item === 'string');
     });
 
-    if (args.length > 1 && args[args.length - 1].indexOf(' ') > -1) {
+    if (args.length > 1 && args[args.length - 1].match(/^:|\s/)) {
         args[args.length - 1] = ':' + args[args.length - 1];
     }
 


### PR DESCRIPTION
Previously the `rawString` function only checked for the presence of a space, but in case the message started with a : and did not contain spaces it would be sent as-is. Which means messages such as `:D` were being interpreted as just `D` by the server.