### PR TITLE
Avoid crash in `/list` with broken servers

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -387,6 +387,17 @@ IrcClient.prototype.whois = function(target, cb) {
 };
 
 
+/**
+ * Explicitely start a channel list, avoiding potential issues with broken IRC servers not sending RPL_LISTSTART
+ */
+IrcClient.prototype.list = function(/* paramN */) {
+    var args = Array.prototype.slice(arguments, 0);
+    this.command_handler.cache('chanlist').channels = [];
+    args.unshift('LIST');
+    this.raw(args);
+};
+
+
 IrcClient.prototype.channel = function(channel_name) {
     return new Channel(this, channel_name);
 };

--- a/src/commands/handlers/misc.js
+++ b/src/commands/handlers/misc.js
@@ -2,13 +2,13 @@ var _ = require('lodash');
 
 var handlers = {
     RPL_LISTSTART: function() {
-        var cache = this.cache('chanlist');
+        var cache = getChanListCache(this);
         cache.channels = [];
         this.emit('channel list start');
     },
 
     RPL_LISTEND: function() {
-        var cache = this.cache('chanlist');
+        var cache = getChanListCache(this);
         if (cache.channels.length) {
             this.emit('channel list', cache.channels);
             cache.channels = [];
@@ -19,7 +19,7 @@ var handlers = {
     },
 
     RPL_LIST: function(command) {
-        var cache = this.cache('chanlist');
+        var cache = getChanListCache(this);
         cache.channels.push({
             channel: command.params[1],
             num_users: parseInt(command.params[2], 10),
@@ -129,3 +129,14 @@ module.exports = function AddCommandHandlers(command_controller) {
         command_controller.addHandler(handler_command, handler);
     });
 };
+
+function getChanListCache(that) {
+    var cache = that.cache('chanlist');
+
+    // fix some IRC networks 
+    if (!cache.channels) {
+        cache.channels = [];
+    }
+
+    return cache;
+}


### PR DESCRIPTION
Some servers appear to not send `RPL_LISTSTART` when starting returning the channel list, which caused a crash due to the array not existing. This adds both a client method to explicitely clear the list, and also adds a safeguard around the array in case or a surprise list response from the server (for example, another client over ZNC).

The helper method is there to ensure a fresh state, in case a server wouldn't send the `RPL_LISTEND` either and thus never deleting the cache.