### PR TITLE
Remove arrow function notation

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -117,7 +117,7 @@ Connection.prototype.connect = function() {
     // 1024 bytes is the maximum length of two RFC1459 IRC messages.
     // May need tweaking when IRCv3 message tags are more widespread
     that.socket.pipe(new TerminatedStream({max_buffer_size: 1024}))
-        .on('data', (line) => {
+        .on('data', function(line) {
             that.read_buffer.push(line);
             that.processReadBuffer();
         });


### PR DESCRIPTION
This is the only use of arrow function notation in the entire library.

One could argue that Node v4.x is now the stable version so it's worth it, but if this is the only change required to make it working on v0.12 (and I haven't tested so maybe it's not), then I think it's worth it.
If anything, it makes it consistent with the rest of the code.