### PR TITLE
Fix connecting to both IPv4 and IPv6 networks

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -45,7 +45,7 @@ Connection.prototype.connect = function() {
     var socket_connect_event_name = 'connect';
     var options = this.options;
     var last_socket_error;
-    var outgoing_addr = that.localAddress || '0.0.0.0';
+    var outgoing_addr = that.localAddress;
     var ircd_host = options.host;
     var ircd_port = options.port || 6667;
 


### PR DESCRIPTION
By passing `{localAddress: undefined}` to `*.connect` node will be able to connect to both IPv4 and IPv6 addresses. Defaulting to `'0.0.0.0'` makes it impossible because you can only bind on `0.0.0.0` or `::`. I don't see any reason to not use the default and let the OS choose the best one.