### PR TITLE
Ensure users in names event is always an array

### DIFF
--- a/src/commands/handlers/channel.js
+++ b/src/commands/handlers/channel.js
@@ -64,7 +64,7 @@ var handlers = {
         var cache = this.cache('names.' + command.params[1]);
         this.emit('userlist', {
             channel: command.params[1],
-            users: cache.members
+            users: cache.members || []
         });
         cache.destroy();
     },


### PR DESCRIPTION
As per the spec: If there is no channel found as in the query, then only RPL_ENDOFNAMES is returned.

Fixes thelounge/lounge#741