### PR TITLE
Remove socketData() debug

### DIFF
--- a/src/transports/net.js
+++ b/src/transports/net.js
@@ -156,8 +156,6 @@ Connection.prototype.onSocketError = function onSocketError(err) {
 };
 
 Connection.prototype.onSocketData = function onSocketData(data) {
-	this.debugOut('socketData()');
-
 	this.incoming_buffer += iconv.decode(data, this.encoding);
 
 	var lines = this.incoming_buffer.split('\n');


### PR DESCRIPTION
It's not particularly useful, and there's a `raw` event for the received lines.