### PR TITLE
Fix case sensitivity of whois cache

### DIFF
--- a/src/commands/handlers/user.js
+++ b/src/commands/handlers/user.js
@@ -47,8 +47,8 @@ var handlers = {
 
 
     RPL_ENDOFWHOIS: function(command) {
-        var nick = command.params[1];
-        var cache = this.cache('whois.' + nick);
+        var cache_key = command.params[1].toLowerCase();
+        var cache = this.cache('whois.' + cache_key);
 
         if (!cache.nick) {
             cache.nick = nick;
@@ -60,14 +60,14 @@ var handlers = {
     },
 
     RPL_AWAY: function(command) {
-        var nick = command.params[1];
-        var cache = this.cache('whois.' + nick);
+        var cache_key = command.params[1].toLowerCase();
+        var cache = this.cache('whois.' + cache_key);
         cache.away = command.params[command.params.length - 1] || 'is away';
     },
 
     RPL_WHOISUSER: function(command) {
-        var nick = command.params[1];
-        var cache = this.cache('whois.' + nick);
+        var cache_key = command.params[1].toLowerCase();
+        var cache = this.cache('whois.' + cache_key);
         cache.nick = command.params[1];
         cache.user = command.params[2];
         cache.host = command.params[3];
@@ -75,45 +75,45 @@ var handlers = {
     },
 
     RPL_WHOISHELPOP: function(command) {
-        var nick = command.params[1];
-        var cache = this.cache('whois.' + nick);
+        var cache_key = command.params[1].toLowerCase();
+        var cache = this.cache('whois.' + cache_key);
         cache.helpop = command.params[command.params.length - 1];
     },
 
     RPL_WHOISBOT: function(command) {
-        var nick = command.params[1];
-        var cache = this.cache('whois.' + nick);
+        var cache_key = command.params[1].toLowerCase();
+        var cache = this.cache('whois.' + cache_key);
         cache.bot = command.params[command.params.length - 1];
     },
 
     RPL_WHOISSERVER: function(command) {
-        var nick = command.params[1];
-        var cache = this.cache('whois.' + nick);
+        var cache_key = command.params[1].toLowerCase();
+        var cache = this.cache('whois.' + cache_key);
         cache.server = command.params[2];
         cache.server_info = command.params[command.params.length - 1];
     },
 
     RPL_WHOISOPERATOR: function(command) {
-        var nick = command.params[1];
-        var cache = this.cache('whois.' + nick);
+        var cache_key = command.params[1].toLowerCase();
+        var cache = this.cache('whois.' + cache_key);
         cache.operator = command.params[command.params.length - 1];
     },
 
     RPL_WHOISCHANNELS:       function(command) {
-        var nick = command.params[1];
-        var cache = this.cache('whois.' + nick);
+        var cache_key = command.params[1].toLowerCase();
+        var cache = this.cache('whois.' + cache_key);
         cache.channels = command.params[command.params.length - 1];
     },
 
     RPL_WHOISMODES: function(command) {
-        var nick = command.params[1];
-        var cache = this.cache('whois.' + nick);
+        var cache_key = command.params[1].toLowerCase();
+        var cache = this.cache('whois.' + cache_key);
         cache.modes = command.params[command.params.length - 1];
     },
 
     RPL_WHOISIDLE: function(command) {
-        var nick = command.params[1];
-        var cache = this.cache('whois.' + nick);
+        var cache_key = command.params[1].toLowerCase();
+        var cache = this.cache('whois.' + cache_key);
         cache.idle = command.params[2];
         if (command.params[3]) {
             cache.logon = command.params[3];
@@ -121,8 +121,8 @@ var handlers = {
     },
 
     RPL_WHOISREGNICK: function(command) {
-        var nick = command.params[1];
-        var cache = this.cache('whois.' + nick);
+        var cache_key = command.params[1].toLowerCase();
+        var cache = this.cache('whois.' + cache_key);
         cache.registered_nick = command.params[command.params.length - 1];
     },
 
@@ -132,26 +132,26 @@ var handlers = {
     },
 
     RPL_WHOISSECURE: function(command) {
-        var nick = command.params[1];
-        var cache = this.cache('whois.' + nick);
+        var cache_key = command.params[1].toLowerCase();
+        var cache = this.cache('whois.' + cache_key);
         cache.secure = true;
     },
 
     RPL_WHOISACCOUNT: function(command) {
-        var nick = command.params[1];
-        var cache = this.cache('whois.' + nick);
+        var cache_key = command.params[1].toLowerCase();
+        var cache = this.cache('whois.' + cache_key);
         cache.account = command.params[2];
     },
 
     RPL_WHOISSPECIAL: function(command) {
-        var nick = command.params[1];
-        var cache = this.cache('whois.' + nick);
+        var cache_key = command.params[1].toLowerCase();
+        var cache = this.cache('whois.' + cache_key);
         cache.special = command.params[command.params.length - 1];
     },
 
     RPL_WHOISACTUALLY: function(command) {
-        var nick = command.params[1];
-        var cache = this.cache('whois.' + nick);
+        var cache_key = command.params[1].toLowerCase();
+        var cache = this.cache('whois.' + cache_key);
         cache.actuallhost = command.params[command.params.length - 1];
     },
 


### PR DESCRIPTION
Fixes case sensitivity of whois queries by forcing the cache keys to lower case, since they are binary matched, and nicks are usually case insensitive.