### PR TITLE
Send all info on unknown command

### DIFF
--- a/src/commands/handler.js
+++ b/src/commands/handler.js
@@ -83,10 +83,7 @@ IrcCommandHandler.prototype.addHandler = function(command, handler) {
 
 
 IrcCommandHandler.prototype.emitUnknownCommand = function(command) {
-    this.emit('unknown command', {
-        command: command.command,
-        params: command.params
-    });
+    this.emit('unknown command', command);
 };
 
 


### PR DESCRIPTION
Hi guys, thanks for a wonderful framework!

I need to do some work with some custom commands that I receive from the server I connect to, and I need to look at this command's tags.

Then I discover that your `unknown command` event for some reason only sends a subset of the command's parameters, which seems a little silly. Because of this, I cannot look at the tags of the commands.

This simple pull request changes this, and makes it so all parameters of the command go through to whoever might listen to this event.