### PR TITLE
Escape IRCv3 tags values

### DIFF
--- a/src/irclineparser.js
+++ b/src/irclineparser.js
@@ -9,6 +9,14 @@ module.exports = parseIrcLine;
  */
 var parse_regex = /^(?:@([^ ]+) )?(?::((?:(?:([^\s!@]+)(?:!([^\s@]+))?)@)?(\S+)) )?((?:[a-zA-Z]+)|(?:[0-9]{3}))(?: ([^:].*?))?(?: :(.*))?$/i;
 
+var escape_tags_map = {
+    '\\\\': '\\',
+    '\\:':  ';',
+    '\\s':  ' ',
+    '\\n':  '\n',
+    '\\r':  '\r'
+};
+
 function parseIrcLine(line) {
     var msg;
     var tags = Object.create(null);
@@ -30,12 +38,9 @@ function parseIrcLine(line) {
             var value = parts[1];
             if (key) {
                 if (typeof value === 'string') {
-                    var segs = value.split(/\\\\/g);
-                    segs = segs.map((v) => v.replace(/\\:/g, ';'));
-                    segs = segs.map((v) => v.replace(/\\s/g, ' '));
-                    segs = segs.map((v) => v.replace(/\\n/g, '\n'));
-                    segs = segs.map((v) => v.replace(/\\r/g, '\r'));
-                    value = segs.join('\\');
+                    value = value.replace(/\\\\|\\:|\\s|\\n|\\r/gi, function(matched) {
+                        return escape_tags_map[matched] || '';
+                    });
                 } else {
                     value = true;
                 }

--- a/src/irclineparser.js
+++ b/src/irclineparser.js
@@ -26,9 +26,21 @@ function parseIrcLine(line) {
     if (msg[1]) {
         msg[1].split(';').forEach(function(tag) {
             var parts = tag.split('=');
-            tags[parts[0].toLowerCase()] = typeof parts[1] === 'undefined' ?
-                true :
-                parts[1];
+            var key = parts[0].toLowerCase();
+            var value = parts[1];
+            if (key) {
+                if (typeof value === 'string') {
+                    var segs = value.split(/\\\\/g);
+                    segs = segs.map((v) => v.replace(/\\:/g, ';'));
+                    segs = segs.map((v) => v.replace(/\\s/g, ' '));
+                    segs = segs.map((v) => v.replace(/\\n/g, '\n'));
+                    segs = segs.map((v) => v.replace(/\\r/g, '\r'));
+                    value = segs.join('\\');
+                } else {
+                    value = true;
+                }
+                tags[key] = value;
+            }
         });
     }
 


### PR DESCRIPTION
Hi, thanks for a great library!

This commit makes the IRCv3 tags parsing more robust, so it parses escaped string values properly, according to [the spec](http://ircv3.net/specs/core/message-tags-3.2.html#escaping-values).