### PR TITLE
Expose message max length and split messages

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -451,10 +451,16 @@ IrcClient.prototype.action = function(target, message) {
     // Maximum length of target + message we can send to the IRC server is 500 characters
     // but we need to leave extra room for the sender prefix so the entire message can
     // be sent from the IRCd to the target without being truncated.
-    var blocks = truncateString(message, this.options.message_max_length);
+
+    // The block length here is the max, but without the non-content characters:
+    // the command name, the space, and the two SOH chars
+
+    var commandName = 'ACTION';
+    var blockLength = this.options.message_max_length - (commandName.length + 3);
+    var blocks = truncateString(message, blockLength);
 
     blocks.forEach(function(block) {
-        that.ctcpRequest(target, 'ACTION', block);
+        that.ctcpRequest(target, commandName, block);
     });
 
     return blocks;

--- a/src/client.js
+++ b/src/client.js
@@ -160,7 +160,7 @@ IrcClient.prototype.proxyIrcEvents = function() {
 
     this.command_handler.on('all', function(event_name, event_arg) {
         client.resetPingTimer();
-        
+
         // Add a reply() function to selected message events
         if (['privmsg', 'notice', 'action'].indexOf(event_name) > -1) {
             event_arg.reply = function(message) {
@@ -238,38 +238,38 @@ IrcClient.prototype.startPeriodicPing = function() {
     var that = this;
     var ping_timer = null;
     var timeout_timer = null;
-    
+
     if(that.options.ping_interval <= 0 || that.options.ping_timeout <= 0) {
         return;
     }
-    
+
     function scheduleNextPing() {
         ping_timer = that.connection.setTimeout(pingServer, that.options.ping_interval*1000);
     }
-    
+
     function resetPingTimer() {
         if(ping_timer) {
             that.connection.clearTimeout(ping_timer);
         }
-        
+
         if(timeout_timer) {
             that.connection.clearTimeout(timeout_timer);
         }
-        
+
         scheduleNextPing();
     }
-    
+
     function pingServer() {
         timeout_timer = that.connection.setTimeout(pingTimeout, that.options.ping_timeout*1000);
         that.ping();
     }
-    
+
     function pingTimeout() {
         that.emit('ping timeout');
         var end_msg = that.rawString('QUIT', 'Ping timeout (' + that.options.ping_timeout + ' seconds)');
         that.connection.end(end_msg, true);
     }
-    
+
     this.resetPingTimer = resetPingTimer;
     scheduleNextPing();
 };


### PR DESCRIPTION
I'm not sure how this is handled in other clients using this framework, so I might be missing something, but I'm having the following issues related to message splitting:

### Message splitting is currently fully internal

If I post a message that's so long that the framework decides that it needs to be split up, then as a client I do not know exactly how the message is split up by the framework, because it happens internally.

Because of this, it will always appear as a single long message to the user who sent it, rather than as a split up message, the way everyone else sees it.

I think it is troubling that I cannot accurately present to the user the way their input looks to everyone else, so in this pull request I try to solve this by returning the blocks that the framework splits the message into, so that the client can then use these to display the message(s).

This happens in the same commit as the one in the next section.

### Non-standard message limit

Secondly, I am currently working with a non-standard IRC server that has different message limits than most other servers.

So, I thought it would be nice to be able to specify as an option exactly what this message limit should be, rather than having it hardcoded. Thus, I added the `message_max_length` option, which has the current default value of `350`. (I also made the code a little more DRY.)

This happens in this commit: https://github.com/kiwiirc/irc-framework/commit/9da94c7adcaaea342c35120211cc20bdf461da46

### Attempt to be more clever in message splitting for actions

In addition, I also notice that since actions are packed as CTCP requests, they have some more characters in the `PRIVMSG` message string in additon to the actual content, so I tried to accomodate for this in a more clever way by subtracting the length of these from the `message_max_length` and using this new value for the splitting.

I am not an expert in IRC internals, and I may be out of my league here, so let me know if this is the incorrect way to handle this, and I'll undo it from the pull request again.

This happens in this commit: https://github.com/kiwiirc/irc-framework/commit/f48efd6237ea5477077fca32a9c08b41a1065993

Sorry for the white space cleanup commit that makes this a little harder to skim. Feel free to check the two commits above with the changes separated.

Thanks again for a great framework!