### PR TITLE
Do not split unicode surrogate pairs

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -601,14 +601,27 @@ IrcClient.prototype.matchAction = function(match_regex, cb) {
 /**
  * Truncate a string into blocks of a set size
  */
+function isHighSurrogate(char_code) {
+    return char_code >= 55296 // d800
+        && char_code <= 56319; // dbff
+}
+
 function truncateString(str, block_size) {
     block_size = block_size || 350;
 
     var blocks = [];
-    var current_pos;
+    var this_block_size;
+    var remaining_string = str;
 
-    for (current_pos = 0; current_pos < str.length; current_pos = current_pos + block_size) {
-        blocks.push(str.substr(current_pos, block_size));
+    while (remaining_string.length) {
+        // Do not split unicode surrogate pairs
+        this_block_size =
+            isHighSurrogate(remaining_string.charCodeAt(block_size - 1))
+            ? block_size - 1
+            : block_size;
+
+        blocks.push(remaining_string.substr(0, this_block_size));
+        remaining_string = remaining_string.substr(this_block_size);
     }
 
     return blocks;


### PR DESCRIPTION
As you may know, some unicode characters have a higher character code value than `FFFF`, and must be expressed as two characters in UTF-8 — a high surrogate followed by a low surrogate. Amongst the characters requiring surrogates are most of the much-loved emojis.

The current message max length splitter does not take into account these pairs, and if you have a cool character, such as 💩, located at the wrong place, it could be split into two very uncool question marks.

I have patched the `truncateMessage` function so that it works with surrogate pairs, while keeping the string slices under the limit. If the string slice has a high surrogate character at the end, that character is then pushed into the beginning of the next slice, and so on.

Here are my before/after testing results, with the new function called `truncateStringsUni` in this case:

![screen shot 2017-06-04 at 14 19 29](https://cloud.githubusercontent.com/assets/80858/26761738/b938d7c4-4935-11e7-9017-819dbe627adb.png)

As you can see below, the slices are always kept within the max limit, even with this more advanced logic:

![screen shot 2017-06-04 at 14 54 46](https://cloud.githubusercontent.com/assets/80858/26761744/d1c75338-4935-11e7-9ccb-85b4dee2bc7f.png)

In order to achieve my goal, I have added a new utility function called `isHighSurrogate`. I was not sure in which file to place this function, so if you have a better idea of where it could belong, let me know.

The function only checks once for a high surrogate character at the end of the string slice, so it isn't possible to troll this logic by posting a message with only high surrogate characters.

Thanks for your consideration!