### PR TITLE
Fix ctcp request type data

### DIFF
--- a/src/commands/handlers/messaging.js
+++ b/src/commands/handlers/messaging.js
@@ -104,7 +104,7 @@ var handlers = {
                     hostname: command.hostname,
                     target: target,
                     group: target_group,
-                    type: (ctcp_command || [null])[0],
+                    type: ctcp_command || null,
                     message: message.substring(1, message.length - 1),
                     time: time,
                     account: command.getTag('account')


### PR DESCRIPTION
Caused by #94; ctcp_command is the 0th index already, so it was instead returning the first letter