### PR TITLE
Parse RPL_WHOISHOST

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -434,6 +434,7 @@ Not all of these options will be available. Some will be missing depending on th
 	nick: 'prawnsalad',
 	user: 'prawn',
 	host: 'manchester.isp.net',
+	actualip: 'sometimes set when using webirc, could be the same as actualhost',
 	actuallhost: 'sometimes set when using webirc',
 	real_name: 'A real prawn',
 	helpop: 'is available for help',

--- a/src/commands/handlers/user.js
+++ b/src/commands/handlers/user.js
@@ -238,7 +238,14 @@ var handlers = {
     RPL_WHOISACTUALLY: function(command) {
         var cache_key = command.params[1].toLowerCase();
         var cache = this.cache('whois.' + cache_key);
-        cache.actuallhost = command.params[command.params.length - 1];
+
+        // <source> 338 <target> <nick> <user>@<host> <ip> :Actual user@host, Actual IP
+        var user_host = command.params[command.params.length - 3];
+        var host = user_host.substring(user_host.indexOf("@") + 1);
+        var ip = command.params[command.params.length - 2];
+
+        cache.actualip = ip;
+        cache.actualhost = host;
     },
 
     RPL_WHOWASUSER: function(command) {

--- a/src/commands/handlers/user.js
+++ b/src/commands/handlers/user.js
@@ -202,8 +202,19 @@ var handlers = {
     },
 
     RPL_WHOISHOST: function(command) {
-        // Ignore this command as we get the host from RPL_WHOISUSER and it contains junk
-        // anyway
+        var cache_key = command.params[1].toLowerCase();
+        var cache = this.cache('whois.' + cache_key);
+
+        var last_param = command.params[command.params.length - 1];
+        // <source> 378 <target> <nick> :is connecting from <user>@<host> <ip>
+        var match = last_param.match(/.*@([^ ]+) ([^ ]+).*$/);  // https://regex101.com/r/AQz7RE/2
+
+        if (!match) {
+            return;
+        }
+
+        cache.actualip = match[2];
+        cache.actualhost = match[1];
     },
 
     RPL_WHOISSECURE: function(command) {


### PR DESCRIPTION
Closes #112 . 
Parses and exposes `actualhost` and `actualip`, since both are provided. ~~~I've also, sort of arbitrarily, decided to only expose `actualhost` if it is a host, and not the ip (ie. they are different values). Let me know if this should change.~~

Because I parse both values above, and `RPL_WHOISACTUALLY` only returns just a string that contains both, I thought I might as well change that to parse them as well, closing #62. 

I've put them in separate commits, in the case that you don't want to change the behaviour of `RPL_WHOISACTUALLY`.