### PR TITLE
Allow the usage of the AUTHCOOKIE mechanism for SASL

### DIFF
--- a/src/commands/handlers/registration.js
+++ b/src/commands/handlers/registration.js
@@ -144,7 +144,11 @@ var handlers = {
                 }
                 if (this.network.cap.enabled.length > 0) {
                     if (this.network.cap.isEnabled('sasl')) {
-                        this.connection.write('AUTHENTICATE PLAIN');
+                        if (this.connection.options.sasl_mechanism === 'AUTHCOOKIE') {
+                            this.connection.write('AUTHENTICATE AUTHCOOKIE');
+                        } else {
+                            this.connection.write('AUTHENTICATE PLAIN');
+                        }
                     } else {
                         this.connection.write('CAP END');
                         this.network.cap.negotiating = false;


### PR DESCRIPTION
Allow the usage of the "AUTHCOOKIE" mechanism that atheme services implement.

This would allow to get an authentication cookie by authenticating outside the IRC connection (i.e. via XMLRPC) and use it for SASL authentication.

The authentication process is exactly the same as PLAIN but instead of using the accounts password the cookie is used.