### PR TITLE
Fix spelling issue events documentation

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -438,7 +438,7 @@ Not all of these options will be available. Some will be missing depending on th
 	user: 'prawn',
 	host: 'manchester.isp.net',
 	actualip: 'sometimes set when using webirc, could be the same as actualhost',
-	actuallhost: 'sometimes set when using webirc',
+	actualhost: 'sometimes set when using webirc',
 	real_name: 'A real prawn',
 	helpop: 'is available for help',
 	bot: 'is a bot',


### PR DESCRIPTION
While doing #113 I had changed the key from `actuallhost` to `actualhost`, but didn't notice, and therefor didn't update the docs

( this will probably break things that relied on that key :\ )