### PR TITLE
Treat multiple RPL_WHOISCHANNELS replies

### DIFF
--- a/src/commands/handlers/user.js
+++ b/src/commands/handlers/user.js
@@ -179,7 +179,11 @@ var handlers = {
     RPL_WHOISCHANNELS:       function(command) {
         var cache_key = command.params[1].toLowerCase();
         var cache = this.cache('whois.' + cache_key);
-        cache.channels = command.params[command.params.length - 1];
+        if (cache.channels) {
+            cache.channels += ' ' + command.params[command.params.length - 1];
+        } else {
+            cache.channels = command.params[command.params.length - 1];
+        }
     },
 
     RPL_WHOISMODES: function(command) {


### PR DESCRIPTION
When an user is in many irc channels only the channels of the last RPL_WHOISCHANNELS message are in the returned object. This patch should fix it.