### PR TITLE
Clear timers on requested disconnect

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -222,6 +222,7 @@ Connection.prototype.end = function(data, had_error) {
     // reconnects happen.
     if (!had_error) {
         this.requested_disconnect = true;
+        this.clearTimers();
     }
 
     if (this.transport) {


### PR DESCRIPTION
I believe this causes reconnect even after explicitly doing `quit` on the client while it's disconnected.