### PR TITLE
Fix 'away' event being triggered in place of 'back' when there is no message

### DIFF
--- a/src/commands/handlers/user.js
+++ b/src/commands/handlers/user.js
@@ -59,7 +59,7 @@ var handlers = {
 
         // Check if we have a server-time
         time = command.getServerTime();
-        const message = command.params[command.params.length - 1];
+        const message = command.params[command.params.length - 1] || '';
         if (message === '') { // back
             this.emit('back', {
                 self: false,


### PR DESCRIPTION
`message` is `undefined` so it triggered `away` incorrectly.