### PR TITLE
[breaking] Bugfix: event naming consistency

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -187,8 +187,8 @@ Debugging messages.
 ~~~javascript
 {
     nick: 'prawnsalad',
-    user: 'prawnsalad',
-    host: 'unaffiliated/prawnsalad',
+    ident: 'prawnsalad',
+    hostname: 'unaffiliated/prawnsalad',
     channel: '#channel',
     when: 000000000
 }
@@ -439,26 +439,26 @@ The `VERSION` CTCP is handled internally and will not trigger this event, unless
 Not all of these options will be available. Some will be missing depending on the network.
 ~~~javascript
 {
-	away: 'away message',
-	nick: 'prawnsalad',
-	user: 'prawn',
-	host: 'manchester.isp.net',
-	actualip: 'sometimes set when using webirc, could be the same as actualhost',
-	actualhost: 'sometimes set when using webirc',
-	real_name: 'A real prawn',
-	helpop: 'is available for help',
-	bot: 'is a bot',
-	server: 'irc.server.net',
-	server_info: '',
-	operator: 'is an operator',
-	channels: 'is on these channels',
-	modes: '',
-	idle: 'idle for 34 secs',
-	logon: 'logged on at X',
-	registered_nick: 'prawnsalad',
-	account: 'logged on account',
-	secure: 'is using SSL/TLS',
-	special: ''
+    away: 'away message',
+    nick: 'prawnsalad',
+    ident: 'prawn',
+    hostname: 'manchester.isp.net',
+    actual_ip: 'sometimes set when using webirc, could be the same as actual_hostname',
+    actual_hostname: 'sometimes set when using webirc',
+    real_name: 'A real prawn',
+    helpop: 'is available for help',
+    bot: 'is a bot',
+    server: 'irc.server.net',
+    server_info: '',
+    operator: 'is an operator',
+    channels: 'is on these channels',
+    modes: '',
+    idle: 'idle for 34 secs',
+    logon: 'logged on at X',
+    registered_nick: 'prawnsalad',
+    account: 'logged on account',
+    secure: 'is using SSL/TLS',
+    special: ''
 }
 ~~~
 
@@ -470,8 +470,13 @@ If the requested user was not found, error will contain 'no_such_nick'.
 {
     nick: 'prawnsalad',
     ident: 'prawn',
-    host: 'manchester.isp.net',
-    real_name: 'prawns real name',
+    hostname: 'manchester.isp.net',
+    actual_ip: 'sometimes set when using webirc, could be the same as actual_hostname',
+    actual_hostname: 'sometimes set when using webirc',
+    real_name: 'A real prawn',
+    server: 'irc.server.net',
+    server_info: 'Thu Jun 14 09:15:51 2018',
+    account: 'logged on account',
     error: ''
 }
 ~~~
@@ -485,8 +490,8 @@ Only on supporting IRC servers with CHGHOST capabilities and 'enable_chghost' se
     nick: 'prawnsalad',
     ident: 'prawns_old_ident',
     hostname: 'prawns.old.hostname',
-    new_user: 'prawns_new_ident',
-    new_host: 'prawns_new_host',
+    new_ident: 'prawns_new_ident',
+    new_hostname: 'prawns_new_host',
     time: time
 }
 ~~~

--- a/src/commands/handlers/channel.js
+++ b/src/commands/handlers/channel.js
@@ -131,8 +131,8 @@ var handlers = {
         var parsed = Helpers.parseMask(command.params[2]);
         this.emit('topicsetby', {
             nick: parsed.nick,
-            user: parsed.user,
-            host: parsed.host,
+            ident: parsed.user,
+            hostname: parsed.host,
             channel: command.params[1],
             when: command.params[3]
         });

--- a/src/commands/handlers/user.js
+++ b/src/commands/handlers/user.js
@@ -314,10 +314,11 @@ var handlers = {
     },
 
     ERR_WASNOSUCHNICK: function(command) {
-        this.emit('whowas', {
-            nick: command.params[1],
-            error: 'no_such_nick'
-        });
+        var cache_key = command.params[1].toLowerCase();
+        var cache = this.cache('whois.' + cache_key);
+
+        cache.nick = command.params[1];
+        cache.error = 'no_such_nick';
     },
 
     RPL_UMODEIS: function(command) {

--- a/src/commands/handlers/user.js
+++ b/src/commands/handlers/user.js
@@ -49,7 +49,7 @@ var handlers = {
             ident: command.ident,
             hostname: command.hostname,
             new_ident: command.params[0],
-            new_host: command.params[1],
+            new_hostname: command.params[1],
             time: time
         });
     },
@@ -168,8 +168,8 @@ var handlers = {
         var cache_key = command.params[1].toLowerCase();
         var cache = this.cache('whois.' + cache_key);
         cache.nick = command.params[1];
-        cache.user = command.params[2];
-        cache.host = command.params[3];
+        cache.ident = command.params[2];
+        cache.hostname = command.params[3];
         cache.real_name = command.params[5];
     },
 
@@ -241,8 +241,8 @@ var handlers = {
             return;
         }
 
-        cache.actualip = match[2];
-        cache.actualhost = match[1];
+        cache.actual_ip = match[2];
+        cache.actual_hostname = match[1];
     },
 
     RPL_WHOISSECURE: function(command) {
@@ -275,18 +275,18 @@ var handlers = {
         // UnrealIRCd uses this numeric for something else resulting in ip+host
         // to be empty, so ignore this is that's the case
         if (ip && host) {
-            cache.actualip = ip;
-            cache.actualhost = host;
+            cache.actual_ip = ip;
+            cache.actual_hostname = host;
         }
     },
 
     RPL_WHOWASUSER: function(command) {
         var cache_key = command.params[1].toLowerCase();
-        var cache = this.cache('whois.' + cache_key), command.params[1]);
+        var cache = this.cache('whois.' + cache_key);
 
         cache.nick = command.params[1];
         cache.ident = command.params[2];
-        cache.host = command.params[3];
+        cache.hostname = command.params[3];
         cache.real_name = command.params[command.params.length - 1];
     },
 
@@ -296,8 +296,9 @@ var handlers = {
         // This is why we borrow from the whois.* cache key ID.
         //
         // This exposes some fields (that may or may not be set).
-        // Valid keys that should always be set: nick, ident, host, real_name
-        // Valid optional keys: actualip, actualhost, account, server, server_info
+        // Valid keys that should always be set: nick, ident, hostname, real_name
+        // Valid optional keys: actual_ip, actual_hostname, account, server,
+        //   server_info
         // More optional fields MAY exist, depending on the type of ircd.
         var cache_key = command.params[1].toLowerCase();
         var cache = this.cache('whois.' + cache_key);
@@ -327,7 +328,7 @@ var handlers = {
     RPL_HOSTCLOACKING: function(command) {
         this.emit('displayed host', {
             nick: command.params[0],
-            host: command.params[1]
+            hostname: command.params[1]
         });
     }
 };


### PR DESCRIPTION
This makes all events consistent in what they send.
```
  actualip -> actual_ip
  actualhost -> actual_hostname
  host -> hostname
  user -> ident
```

Branches off of https://github.com/kiwiirc/irc-framework/pull/157 (depends on/contains)

A quick grep showing all cache entries (does not include literal `event.emit(...)` statements):
```
$ grep -r 'cache.[^ ]+ =' -P --no-filename | sed 's/ //g' | sed 's/=.*//g' | sort -u
cache.account
cache.actual_hostname
cache.actual_ip
cache.away
cache.bans
cache.bot
cache.channels
cache.commands
cache.error
cache.helpop
cache.hostname
cache.ident
cache.idle
cache.links
cache.logon
cache.members
cache.modes
cache.motd
cache.nick
*cache.nicks
cache.operator
cache.params
cache.real_name
cache.registered_nick
cache.secure
cache.server
cache.server_info
cache.special
cache.type
this._caches[id]
varcache_key

```

Closes #158.