### PR TITLE
Emit raw mode string in mode events

### DIFF
--- a/src/commands/handlers/channel.js
+++ b/src/commands/handlers/channel.js
@@ -8,11 +8,15 @@ var Helpers = require('../../helpers');
 var handlers = {
     RPL_CHANNELMODEIS: function(command) {
         var channel = command.params[1];
-        var modes = this.parseModeList.call(this, command.params[2], command.params.slice(3));
+        var raw_modes = command.params[2];
+        var raw_params = command.params.slice(3);
+        var modes = this.parseModeList.call(this, raw_modes, raw_params);
 
         this.emit('channel info', {
             channel: channel,
-            modes: modes
+            modes: modes,
+            raw_modes: raw_modes,
+            raw_params: raw_params
         });
     },
 

--- a/src/commands/handlers/misc.js
+++ b/src/commands/handlers/misc.js
@@ -127,13 +127,17 @@ var handlers = {
         var time = command.getServerTime();
 
         // Get a JSON representation of the modes
-        var modes = this.parseModeList(command.params[1], command.params.slice(2));
+        var raw_modes = command.params[1];
+        var raw_params = command.params.slice(2);
+        var modes = this.parseModeList(raw_modes, raw_params);
 
         this.emit('mode', {
             target: command.params[0],
             nick: command.nick || command.prefix || '',
             modes: modes,
-            time: time
+            time: time,
+            raw_modes: raw_modes,
+            raw_params: raw_params
         });
     },
 


### PR DESCRIPTION
Sometimes parsed modes are not necessary and the raw string would suffice (e.g. displaying it in a response to a command) without having to restructure it back from the parsed array.