### PR TITLE
Force \r\n for all network rights, as per RFC

### DIFF
--- a/src/transports/net.js
+++ b/src/transports/net.js
@@ -37,9 +37,9 @@ module.exports = class Connection extends EventEmitter {
     writeLine(line, cb) {
     	if (this.socket && this.isConnected()) {
     		if (this.encoding !== 'utf8') {
-    			this.socket.write(iconv.encode(line + '\n', this.encoding), cb);
+    			this.socket.write(iconv.encode(line + '\r\n', this.encoding), cb);
     		} else {
-    			this.socket.write(line + '\n', cb);
+    			this.socket.write(line + '\r\n', cb);
     		}
     	}
     }


### PR DESCRIPTION
as per https://github.com/insomniacslk/irc-slack/pull/56#issuecomment-451644740

> IRC messages are always lines of characters terminated with a CR-LF
(Carriage Return - Line Feed) pair, and these messages SHALL NOT
exceed 512 characters in length, counting all characters including
the trailing CR-LF.

So IRC spec says messages need to be \r\n, so quick patch to do so.

There doesn't seem to be a test that breaks with this.