### PR TITLE
Fix nick collisions where uuid's are sent from the server

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -213,6 +213,11 @@ module.exports = class IrcClient extends EventEmitter {
 
         commands.on('nick', function(event) {
             if (client.user.nick === event.nick) {
+                // nicks starting with numbers are reserved for uuids
+                // we dont want to store these as they cannot be used
+                if (event.new_nick.match(/^\d/)) {
+                    return;
+                }
                 client.user.nick = event.new_nick;
             }
         });


### PR DESCRIPTION
to replicate this issue try connecting two clients using the same nick at the same time.
first should fail with registration timeout