### PR TITLE
Use STATUSMSG when parsing target groups

### DIFF
--- a/src/commands/handlers/registration.js
+++ b/src/commands/handlers/registration.js
@@ -47,6 +47,8 @@ var handlers = {
                 }
             } else if (option[0] === 'CHANTYPES') {
                 this.network.options.CHANTYPES = this.network.options.CHANTYPES.split('');
+            } else if (option[0] === 'STATUSMSG') {
+                this.network.options.STATUSMSG = this.network.options.STATUSMSG.split('');
             } else if (option[0] === 'CHANMODES') {
                 this.network.options.CHANMODES = option[1].split(',');
             } else if (option[0] === 'NETWORK') {


### PR DESCRIPTION
Fixes #185. I tested this on Freenode (#chan and @#chan) and on W3 (it has no statusmsg) and it appears to work correctly.

I switched `PREFIX` to `STATUSMSG` and added an additional check that the next character is actually a channel prefix as well.