### PR TITLE
Return correct target_group

### DIFF
--- a/src/commands/handlers/messaging.js
+++ b/src/commands/handlers/messaging.js
@@ -153,7 +153,7 @@ function parseTargetGroup(network, target) {
         if (prefix === target[0]) {
             target = target.substring(1);
 
-            return target[0];
+            return prefix;
         }
     });
 


### PR DESCRIPTION
Fixed correctly returning the group: `{ target: '#channel', target_group: '@' }`

Missed that by mistake when I changed the return.