### PR TITLE
Fix cap negotiation not being set to true

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -104,6 +104,12 @@ module.exports = class IrcClient extends EventEmitter {
             client.startPeriodicPing();
         });
 
+        client.connection.on('connecting', function() {
+            // Reset cap negotiation to false on a new connection
+            // This prevents stale state if a connection gets closed during CAP negotiation
+            client.network.cap.negotiating = false;
+        });
+
         // IRC command routing
         client.connection.on('message', function(message, raw_line) {
             client.raw_middleware.handle([message.command, message, raw_line, client], function(err) {

--- a/src/commands/handlers/registration.js
+++ b/src/commands/handlers/registration.js
@@ -133,6 +133,7 @@ var handlers = {
                 // line which will not have * set for params[2]
                 if (command.params[2] !== '*') {
                     if (request_caps.length > 0) {
+                        this.network.cap.negotiating = true;
                         this.connection.write('CAP REQ :' + request_caps.join(' '));
                     } else {
                         this.connection.write('CAP END');


### PR DESCRIPTION
Meaning doing SASL auth would prevent CAP END from being sent.

This already prevented RPL_SASLLOGGEDIN from sending CAP END, and after #184 RPL_LOGGEDIN would no longer send one either.

I set it to `true` in `LS`, but since the condition is only checked in auth related numerics, I could put it in `ACK` before sending `AUTHENTICATE`.

Should probably also reset it to `false` when a new connection is opened?