### PR TITLE
Simplify getServerTime

### DIFF
--- a/test/servertime.js
+++ b/test/servertime.js
@@ -1,0 +1,68 @@
+"use strict";
+/*globals describe, it */
+const chai = require('chai'),
+    IrcCommand = require('../src/commands/command'),
+    expect = chai.expect;
+
+describe('src/commands/command.js', function () {
+    describe('getServerTime parsing', function () {
+
+        it('should parse ISO8601 correctly', function () {
+            const cmd = new IrcCommand('', {
+                tags: {
+                    time: '2011-10-10T14:48:00Z',
+                }
+            });
+
+            expect(cmd.getServerTime()).to.equal(1318258080000);
+        });
+
+        it('should parse unix timestamps', function () {
+            const cmd = new IrcCommand('', {
+                tags: {
+                    time: '1318258080',
+                }
+            });
+
+            expect(cmd.getServerTime()).to.equal(1318258080000);
+        });
+
+        it('should parse unix timestamps with milliseconds', function () {
+            const cmd = new IrcCommand('', {
+                tags: {
+                    time: '1318258080.1234',
+                }
+            });
+
+            expect(cmd.getServerTime()).to.equal(1318258080123);
+        });
+
+        it('should return undefined for missing time', function () {
+            const cmd = new IrcCommand('', {
+                tags: {}
+            });
+
+            expect(cmd.getServerTime()).to.be.undefined;
+        });
+
+        it('should return undefined for empty time', function () {
+            const cmd = new IrcCommand('', {
+                tags: {
+                    time: '',
+                }
+            });
+
+            expect(cmd.getServerTime()).to.be.undefined;
+        });
+
+        it('should return undefined for malformed time', function () {
+            const cmd = new IrcCommand('', {
+                tags: {
+                    time: 'definetelyNotAtimestamp',
+                }
+            });
+
+            expect(cmd.getServerTime()).to.be.undefined;
+        });
+    });
+});


### PR DESCRIPTION
@prawnsalad Do you remember any details as to why it was implemented in this elaborate way initially?

Message tags parser will always return a string, so the number type check is unnecessary. `server-time` is specced as ISO8601 so the fallback to numeric timestamp is also unnecessary.

I tested `Date.parse` in NodeJS, Edge, Chrome and Firefox and all of them gave correct results in regards to timezones and parsing. The ISO8601 has been baked into the ECMA standard June 2011 so we should be good here.

https://www.ecma-international.org/ecma-262/5.1/#sec-15.9.4.2
https://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.15