### PR TITLE
Use node buffers and decode full lines

### DIFF
--- a/src/transports/net.js
+++ b/src/transports/net.js
@@ -174,7 +174,7 @@ module.exports = class Connection extends EventEmitter {
 
         while (true) {
             // Search for the next new line in the buffered data
-            const endIndex = this.incoming_buffer.indexOf('\n', startIndex) + 1;
+            const endIndex = this.incoming_buffer.indexOf(0x0A, startIndex) + 1;
 
             // If this message is partial, keep it in the buffer until more data arrives.
             // If startIndex is equal to incoming_buffer.length, that means we reached the end

--- a/src/transports/net.js
+++ b/src/transports/net.js
@@ -6,7 +6,6 @@
 
 var net             = require('net');
 var tls             = require('tls');
-var util            = require('util');
 var EventEmitter    = require('events').EventEmitter;
 var Socks           = require('socksjs');
 var iconv           = require('iconv-lite');
@@ -27,7 +26,6 @@ module.exports = class Connection extends EventEmitter {
         this.socket_events = [];
 
         this.encoding = 'utf8';
-        this.incoming_buffer = '';
     }
 
     isConnected() {
@@ -73,6 +71,7 @@ module.exports = class Connection extends EventEmitter {
 
         this.disposeSocket();
         this.requested_disconnect = false;
+        this.incoming_buffer = Buffer.from('');
 
         // Include server name (SNI) if provided host is not an IP address
         if (!this.getAddressFamily(ircd_host)) {
@@ -164,17 +163,34 @@ module.exports = class Connection extends EventEmitter {
     }
 
     onSocketData(data) {
-    	this.incoming_buffer += iconv.decode(data, this.encoding);
+        // Buffer incoming data because multiple messages can arrive at once
+        // without necessarily ending in a new line
+        this.incoming_buffer = Buffer.concat(
+            [this.incoming_buffer, data],
+            this.incoming_buffer.length + data.length
+        );
 
-    	var lines = this.incoming_buffer.split('\n');
-    	if (lines[lines.length - 1] !== '') {
-    		this.incoming_buffer = lines.pop();
-    	} else {
-    		lines.pop();
-    		this.incoming_buffer = '';
-    	}
+        let startIndex = 0;
 
-    	lines.forEach(line => this.emit('line', line));
+        while (true) {
+            // Search for the next new line in the buffered data
+            const endIndex = this.incoming_buffer.indexOf('\n', startIndex) + 1;
+
+            // If this message is partial, keep it in the buffer until more data arrives.
+            // If startIndex is equal to incoming_buffer.length, that means we reached the end
+            // of the buffer and it ended on a new line, slice will return an empty buffer.
+            if (endIndex === 0) {
+                this.incoming_buffer = this.incoming_buffer.slice(startIndex);
+                break;
+            }
+
+            // Slice a single message delimited by a new line, decode it and emit it out
+            let line = this.incoming_buffer.slice(startIndex, endIndex);
+            line = iconv.decode(line, this.encoding);
+            this.emit('line', line);
+
+            startIndex = endIndex;
+        }
     }
 
 


### PR DESCRIPTION
This is a change I noticed in #142 but I rewrote it myself (after looking at that PR, it doesn't appear to actually implement the buffering correctly)

This change will use buffers and will split it into lines from said buffer. `iconv.decode` is now called on a single IRC line instead of the whole data buffer passed from the socket (which I only assume could cause troubles on partial data).

I also no longer keep an array of lines and directly emit each split and decoded line. There's no need to keep an array because `split` is no longer used (it doesn't exist on Buffer either). This _should_ lower memory consumption.

I also reset `incoming_buffer` when calling `connect()` instead of constructor, which should clear out any remaining data if the socket dies.

I tested it with ZNC playback where it feels a lot of data, and it works fine.