### PR TITLE
Use trailing if last param starts with a semicolon

### DIFF
--- a/src/ircmessage.js
+++ b/src/ircmessage.js
@@ -28,7 +28,7 @@ module.exports = class IrcMessage {
 
         if (this.params.length > 0) {
             this.params.forEach((param, idx) => {
-                if (idx === this.params.length - 1 && param.indexOf(' ') > -1) {
+                if (idx === this.params.length - 1 && (param.indexOf(' ') > -1 || param.indexOf(':') === 0)) {
                     parts.push(':' + param);
                 } else {
                     parts.push(param);

--- a/src/ircmessage.js
+++ b/src/ircmessage.js
@@ -28,7 +28,7 @@ module.exports = class IrcMessage {
 
         if (this.params.length > 0) {
             this.params.forEach((param, idx) => {
-                if (idx === this.params.length - 1 && (param.indexOf(' ') > -1 || param.indexOf(':') === 0)) {
+                if (idx === this.params.length - 1 && (param.indexOf(' ') > -1 || param[0] === ':')) {
                     parts.push(':' + param);
                 } else {
                     parts.push(param);


### PR DESCRIPTION
When constructing params, if the final param starts with a `:` then an additional `:` should be prepended.

For example:
```
msg: IrcMessage {
  tags: [Object: null prototype] { time: '2019-05-12T23:24:37.422Z' },
  prefix: 'dan-bnc5!~user@127.0.0.1',
  nick: 'dan-bnc5',
  ident: '~user',
  hostname: '127.0.0.1',
  command: 'PRIVMSG',
  params: [ '#test', ':)' ]
}
```

should become:
```
@time=2019-05-12T23:24:37.422Z :dan-bnc5!~user@127.0.0.1 PRIVMSG #test ::)
```

rather than (currently):
```
@time=2019-05-12T23:24:37.422Z :dan-bnc5!~user@127.0.0.1 PRIVMSG #test :)
```