### PR TITLE
Allow extra_args passed to client.mode() to be an array

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -440,7 +440,12 @@ module.exports = class IrcClient extends EventEmitter {
         var raw = ['MODE', channel, mode];
 
         if (extra_args) {
-            raw.push(extra_args);
+            if (Array.isArray(extra_args)) {
+                raw = raw.concat(extra_args);
+            }
+            else {
+                raw.push(extra_args);
+            }
         }
 
         this.raw(raw);


### PR DESCRIPTION
This will enable `client.mode('#chan', '+oo', 'nick1', 'nick2');` without breaking backwards compatibility 