### PR TITLE
Dont crash when server (ex irslackd) doesn't actually send modes

### DIFF
--- a/src/commands/handler.js
+++ b/src/commands/handler.js
@@ -112,6 +112,10 @@ module.exports = class IrcCommandHandler extends EventEmitter {
         var j;
         var add;
 
+        if (!mode_string) {
+            return modes;
+        }
+
         prefixes = _.reduce(prefixes, function(list, prefix) {
             list.push(prefix.mode);
             return list;


### PR DESCRIPTION
When I tried to join a irslackd (https://github.com/adsr/irslackd) server, thelounge crashed

I've added debugging to the server, looks like its not sending any flags after mode
```
irc_out: joinChannel #production
irc_out :gavin JOIN #production
irc_out :irslackd 353 gavin = #production :gavin gavin
irc_out :irslackd MODE #production
irc_in MODE #production
```

I _think_ mode should be populated but empty with based on https://tools.ietf.org/html/rfc1459#section-4.2.3.1 but I figure not crashing is a good plan