### PR TITLE
Do not crash on invalid BATCH commands

### DIFF
--- a/src/commands/handler.js
+++ b/src/commands/handler.js
@@ -36,8 +36,9 @@ module.exports = class IrcCommandHandler extends EventEmitter {
         // Batched commands will be collected and executed as a transaction
         var batch_id = irc_command.getTag('batch');
         if (batch_id) {
-            var cache = this.cache('batch.' + batch_id);
-            if (cache) {
+            const cache_key = 'batch.' + batch_id;
+            if (this.hasCache(cache_key)) {
+                const cache = this.cache(cache_key);
                 cache.commands.push(irc_command);
             } else {
                 // If we don't have this batch ID in cache, it either means that the


### PR DESCRIPTION
Fixes this crash that happened on a server that sent a misformatted batch command: https://pastebin.com/6SbWUyk1

I also changed batch tag to use `hasCache` because just calling `cache` creates a new cache, and it would never be false.