### PR TITLE
Send CAP END if there is nothing to negotiate

### DIFF
--- a/src/commands/handlers/registration.js
+++ b/src/commands/handlers/registration.js
@@ -159,7 +159,7 @@ var handlers = {
                 if (handler.network.cap.requested.length > 0) {
                     handler.network.cap.negotiating = true;
                     handler.connection.write('CAP REQ :' + handler.network.cap.requested.join(' '));
-                } else if (handler.network.cap.negotiating) {
+                } else {
                     handler.connection.write('CAP END');
                     handler.network.cap.negotiating = false;
                 }


### PR DESCRIPTION
Example log where the connection times out: https://pastebin.com/8EAfpWbq

Server sends `:server.com CAP 912AACPTF LS :tls`, and irc-fw never ends the negotiation.

This `if` was added here: https://github.com/kiwiirc/irc-framework/commit/f43d8f977281623d1904685ca8c1c6ddac0ca964