### PR TITLE
Fire write() callback when not connected, add extra debug

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -170,6 +170,7 @@ module.exports = class IrcClient extends EventEmitter {
         client._applyDefaultOptions(options);
 
         if (client.connection && client.connection.connected) {
+            client.debugOut('connect() called when already connected');
             client.connection.end();
         }
 
@@ -307,6 +308,7 @@ module.exports = class IrcClient extends EventEmitter {
         }
 
         function pingTimeout() {
+            that.debugOut('Ping timeout (' + that.options.ping_timeout + ' seconds)');
             that.emit('ping timeout');
             var end_msg = that.rawString('QUIT', 'Ping timeout (' + that.options.ping_timeout + ' seconds)');
             that.connection.end(end_msg, true);
@@ -318,6 +320,10 @@ module.exports = class IrcClient extends EventEmitter {
 
     // Gets overridden with a function in startPeriodicPing(). Only set here for completeness.
     resetPingTimeoutTimer() {}
+
+    debugOut(out) {
+        this.emit('debug', 'Client ' + out);
+    }
 
     /**
      * Client API

--- a/src/connection.js
+++ b/src/connection.js
@@ -164,7 +164,9 @@ module.exports = class Connection extends EventEmitter {
 
     write(data, callback) {
         if (!this.connected || this.requested_disconnect) {
-            return 0;
+            this.debugOut('write() called when not connected');
+            callback();
+            return false;
         }
 
         this.emit('raw', { line: data, from_server: false });

--- a/src/connection.js
+++ b/src/connection.js
@@ -165,7 +165,7 @@ module.exports = class Connection extends EventEmitter {
     write(data, callback) {
         if (!this.connected || this.requested_disconnect) {
             this.debugOut('write() called when not connected');
-            callback();
+            setTimeout(callback, 0); // fire in next tick
             return false;
         }
 

--- a/src/transports/net.js
+++ b/src/transports/net.js
@@ -41,7 +41,7 @@ module.exports = class Connection extends EventEmitter {
             }
         } else {
             this.debugOut('writeLine() called when not connected');
-            cb();
+            process.nextTick(cb);
         }
     }
 

--- a/src/transports/net.js
+++ b/src/transports/net.js
@@ -39,6 +39,9 @@ module.exports = class Connection extends EventEmitter {
             } else {
                 this.socket.write(line + '\r\n', cb);
             }
+        } else {
+            this.debugOut('writeLine() called when not connected');
+            cb();
         }
     }
 

--- a/src/transports/websocket.js
+++ b/src/transports/websocket.js
@@ -28,6 +28,8 @@ module.exports = class Connection extends EventEmitter {
         this.debugOut('writeLine() socket=' + (this.socket ? 'yes' : 'no') + ' connected=' + this.connected);
         if (this.socket && this.connected) {
             this.socket.send(line, cb);
+        } else {
+            setTimeout(cb, 0);
         }
     }
 


### PR DESCRIPTION
`connection.end` relies on the callback, and it may not be called in some cases.

I'm also thinking that `socket.write` itself may not fire it when socket is hanging.

See https://github.com/thelounge/thelounge/issues/3697