### PR TITLE
Add handler for ERR_UNKNOWNCOMMAND (421)

### DIFF
--- a/src/commands/handlers/generics.js
+++ b/src/commands/handlers/generics.js
@@ -105,6 +105,13 @@ var generics = {
         error: 'chanop_privs_needed',
         channel: 1,
         reason: -1
+    },
+
+    ERR_UNKNOWNCOMMAND: {
+        event: 'irc error',
+        error: 'unknown_command',
+        command: 1,
+        reason: -1
     }
 };
 


### PR DESCRIPTION
By adding a handler to ERR_UNKNOWNCOMMAND, it will be possible to customize the unknown command error message that clients receive.

Example: https://github.com/thelounge/thelounge/pull/3741