### PR TITLE
Trigger CAP events for consumers

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -575,3 +575,17 @@ A `batch end <type>` event is also triggered.
     commands: []
 }
 ~~~
+
+
+**cap ls**, **cap ack**, **cap nak**, **cap list**, **cap new**, **cap del**
+
+Triggered for each `CAP` command, lists the sent capabilities list.
+
+~~~javascript
+{
+    command: 'LS',
+    capabilities: {
+        'sts': 'port=6697'
+    }
+}
+~~~

--- a/src/commands/handlers/registration.js
+++ b/src/commands/handlers/registration.js
@@ -101,6 +101,7 @@ var handlers = {
                 // CAPs in 3.2 may be in the form of CAP=VAL. So seperate those out
                 var sep = cap.indexOf('=');
                 if (sep === -1) {
+                    capability_values[cap] = '';
                     return cap;
                 }
 
@@ -232,6 +233,11 @@ var handlers = {
             );
             break;
         }
+
+        handler.emit('cap ' + command.params[1].toLowerCase(), {
+            command: command.params[1],
+            capabilities: capability_values,
+        });
     },
 
     AUTHENTICATE: function(command, handler) {


### PR DESCRIPTION
Looks like this:
```
{
  command: 'LS',
  capabilities: [Object: null prototype] {
    'account-notify': '',
    'away-notify': '',
    'cap-notify': '',
    chghost: '',
    'extended-join': '',
    'identify-msg': '',
    'multi-prefix': '',
    sasl: '',
    tls: ''
  }
}
```