### PR TITLE
Fix duplicate connections/events

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -51,6 +51,7 @@ module.exports = class Connection extends EventEmitter {
         this.auto_reconnect_max_retries = options.auto_reconnect_max_retries || 3;
 
         if (this.transport) {
+            this.clearTimers();
             this.transport.removeAllListeners();
         }
         this.transport = new options.transport(options);

--- a/src/connection.js
+++ b/src/connection.js
@@ -53,6 +53,7 @@ module.exports = class Connection extends EventEmitter {
         if (this.transport) {
             this.clearTimers();
             this.transport.removeAllListeners();
+            this.transport.disposeSocket();
         }
         this.transport = new options.transport(options);
 


### PR DESCRIPTION
Repro:
- Disconnect and have the reconnection timer running
- Call `connect()`
