### PR TITLE
update client defaults to new variable

### DIFF
--- a/docs/clientapi.md
+++ b/docs/clientapi.md
@@ -13,7 +13,7 @@ new Irc.Client({
     enable_chghost: false,
     enable_echomessage: false,
     auto_reconnect: true,
-    auto_reconnect_wait: 4000,
+    auto_reconnect_max_wait: 300000,
     auto_reconnect_max_retries: 3,
     ping_interval: 30,
     ping_timeout: 120,

--- a/src/client.js
+++ b/src/client.js
@@ -49,7 +49,7 @@ module.exports = class IrcClient extends EventEmitter {
             enable_setname: false,
             enable_echomessage: false,
             auto_reconnect: true,
-            auto_reconnect_wait: 4000,
+            auto_reconnect_max_wait: 300000,
             auto_reconnect_max_retries: 3,
             ping_interval: 30,
             ping_timeout: 120,


### PR DESCRIPTION
2321afa replaced the auto_reconnect_wait variable with auto_reconnect_max_wait
but left it in the client defaults and the docs.