### PR TITLE
Move SOCKS support to a more maintained package (fixes timeout)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lodash": "^4.17.15",
     "middleware-handler": "^0.2.0",
     "regenerator-runtime": "^0.13.5",
-    "socksjs": "^0.5.0"
+    "socks": "^2.6.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
@@ -39,14 +39,14 @@
     "webpack-cli": "^3.3.11"
   },
   "scripts": {
-    "test": "yarn run lint && yarn run coverage",
+    "test": "npm run-script lint && npm run-script coverage",
     "lint": "eslint src/ examples/ test/",
     "unit-test": "mocha --recursive",
     "coverage": "nyc mocha -R dot test/ --recursive",
-    "build": "yarn run build-browser-es5 && yarn run build-browser-bundle",
+    "build": "npm run-script build-browser-es5 && npm run-script build-browser-bundle",
     "build-browser-es5": "babel src/ -d dist/browser/src/ --delete-dir-on-start && shx mv ./dist/browser/src/transports/default_browser.js ./dist/browser/src/transports/default.js && shx rm ./dist/browser/src/transports/net.js",
     "build-browser-bundle": "webpack --config webpack.config.js",
-    "prepare": "yarn run build"
+    "prepare": "npm run-script build"
   },
   "repository": {
     "type": "git",

--- a/src/transports/net.js
+++ b/src/transports/net.js
@@ -111,7 +111,7 @@ module.exports = class Connection extends EventEmitter {
                 }
             }).then(info => {
                 let connection = info.socket;
-                if(options.tls || options.ssl) {
+                if (options.tls || options.ssl) {
                     connection = tls.connect({
                         socket: connection,
                         servername: sni,
@@ -121,7 +121,7 @@ module.exports = class Connection extends EventEmitter {
                     });
                 }
                 this.socket = connection;
-                this.debugOut("SOCKS connection established.");
+                this.debugOut('SOCKS connection established.');
                 this._onSocketCreate(options, connection);
             }).catch(this.onSocketError.bind(this));
         } else {
@@ -149,15 +149,15 @@ module.exports = class Connection extends EventEmitter {
         }
     }
 
-  _onSocketCreate(options, socket) {
-        this.debugOut("Socket created!");
+    _onSocketCreate(options, socket) {
+        this.debugOut('Socket created!');
         if (options.ping_interval > 0 && options.ping_timeout > 0) {
             socket.setTimeout((options.ping_interval + options.ping_timeout) * 1000);
         }
 
         // We need the raw socket connect event.
         // It seems SOCKS gives us the socket in an already open state! Deal with that:
-        if (socket.readyState != "opening") {
+        if (socket.readyState !== 'opening') {
             this.onSocketRawConnected();
             if (!(socket instanceof tls.TLSSocket)) {
                 this.onSocketFullyConnected();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3077,10 +3077,10 @@ invariant@^2.2.2, invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
-ipaddr.js@0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-0.1.3.tgz#27a9ca37f148d2102b0ef191ccbf2c51a8f025c6"
-  integrity sha1-J6nKN/FI0hArDvGRzL8sUajwJcY=
+ip@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
+  integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -4923,6 +4923,11 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
+smart-buffer@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba"
+  integrity sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -4953,12 +4958,13 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-socksjs@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/socksjs/-/socksjs-0.5.0.tgz#77b005e32d1bfc96e560fedd5d7eedcf120f87e3"
-  integrity sha1-d7AF4y0b/JblYP7dXX7tzxIPh+M=
+socks@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.1.tgz#989e6534a07cf337deb1b1c94aaa44296520d30e"
+  integrity sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==
   dependencies:
-    ipaddr.js "0.1.3"
+    ip "^1.1.5"
+    smart-buffer "^4.1.0"
 
 source-list-map@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Hi there, it seems [socksjs is a dead package (archived repo)](https://github.com/M2Ys4U/socksjs) and wasn't even giving an actual net.Socket (which caused crashes when timeouts were enabled!). This PR changes SOCKS support to use the [socks package](https://npmjs.com/package/socks) which is more maintained and just seems generally better from what I've seen. Currently, it's hardcoded to only use SOCKSv5, but `socks` can support higher versions, I just didn't want to change the existing API.