### PR TITLE
RPL_ISUPPORT: fix handling of empty string in PREFIX

### DIFF
--- a/src/commands/handlers/registration.js
+++ b/src/commands/handlers/registration.js
@@ -65,6 +65,8 @@ const handlers = {
                             mode: matches[1].charAt(j)
                         });
                     }
+                } else if (option[1] === '') {
+                    handler.network.options.PREFIX = [];
                 }
             } else if (option[0] === 'CHANTYPES') {
                 handler.network.options.CHANTYPES = handler.network.options.CHANTYPES.split('');


### PR DESCRIPTION
Callers expect an array even if the string is empty, give them that.

Happened in thelounge when connecting to psyced.org... they return the following data:
```js
{
    options: {
    CASEMAPPING: 'ascii',
    PREFIX: '',
    PSYC: '.99',
    ALIAS: true,
    AVAILABILITY: true,
    FRIEND: true,
    HISTORY: true,
    MOOD: true,
    SHOUT: true,
    SSET: true,
    STATUS: true,
    SUBSCRIBE: true,
    THREAD: true,
    TRUST: true,
    CHANTYPES: [ '#' ],
    CHANMODES: [ '' ],
    NICKLEN: '256',
    CHANNELLEN: '256',
    TOPICLEN: '444',
    KICKLEN: '444',
    AWAYLEN: '444',
    MAXTARGETS: '1',
    CHARSET: 'UTF-8',
    NETWORK: 'psyced.org',
    CTCP: 'PRESENCE,TS',
    UNIFORMS: 'psyc,xmpp',
    'ARE SUPPORTED BY THIS SERVER': true
  },
  cap: [],
  tags: {}
}
```

This makes irc-framework return `{PREFIX: ''}` (among other keys) which is undesired I guess