### PR TITLE
Add missing ! for caseCompare in mode event handler

### DIFF
--- a/src/channel.js
+++ b/src/channel.js
@@ -76,7 +76,7 @@ module.exports = class IrcChannel {
             }
             */
 
-            if (irc_client.caseCompare(event.target, this.name)) {
+            if (!irc_client.caseCompare(event.target, this.name)) {
                 return;
             }
 


### PR DESCRIPTION
2c360d1ff9c7e1b3e8e201a1ec8ad9c52a3baee1 had a missing ! in the mode event handler that caused mode changes not to be tracked properly.