### PR TITLE
handle RPL_UMODEIS

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -427,6 +427,20 @@ The `VERSION` CTCP is handled internally and will not trigger this event, unless
 ~~~
 
 
+**user info**
+
+May be sent upon connecting to a server or when a `MODE <nick>` was executed.
+Corresponds to 'RPL_UMODEIS'.
+~~~javascript
+  {
+      nick: 'prawnsalad',
+      raw_modes: '+Ri',
+      tags: {}
+  }
+~~~
+
+
+
 **away**
 
 `self` will be `true` if this is a response to your `away` command.

--- a/src/commands/handlers/user.js
+++ b/src/commands/handlers/user.js
@@ -359,8 +359,13 @@ const handlers = {
     },
 
     RPL_UMODEIS: function(command, handler) {
-        // handler.connection.umodes = the modes
-        // TODO: this
+        const nick = command.params[0];
+        const raw_modes = command.params[1];
+        handler.emit('user info', {
+            nick: nick,
+            raw_modes: raw_modes,
+            tags: command.tags
+        });
     },
 
     RPL_HOSTCLOAKING: function(command, handler) {


### PR DESCRIPTION
As discussed on IRC, this now emits a user info and doesn't try to save any state in the client