### PR TITLE
Rework client ping and timeout functions

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -404,7 +404,7 @@ module.exports = class IrcClient extends EventEmitter {
     }
 
     ping(message) {
-        this.raw('PING', message || 'kiwitime-' + Date.now());
+        this.raw('PING', message || Date.now());
     }
 
     changeNick(nick) {

--- a/src/client.js
+++ b/src/client.js
@@ -404,7 +404,7 @@ module.exports = class IrcClient extends EventEmitter {
     }
 
     ping(message) {
-        this.raw('PING', message || Date.now());
+        this.raw('PING', message || Date.now().toString());
     }
 
     changeNick(nick) {

--- a/src/commands/handlers/misc.js
+++ b/src/commands/handlers/misc.js
@@ -155,6 +155,13 @@ const handlers = {
 
     PING: function(command, handler) {
         handler.connection.write('PONG ' + command.params[command.params.length - 1]);
+
+        const time = command.getServerTime();
+        handler.emit('ping', {
+            message: command.params[1],
+            time: time,
+            tags: command.tags
+        });
     },
 
     PONG: function(command, handler) {

--- a/src/commands/handlers/registration.js
+++ b/src/commands/handlers/registration.js
@@ -22,7 +22,7 @@ const handlers = {
         // to an IRC server, not now(). Send a PING so that we can get a reliable time from PONG
         if (handler.network.cap.isEnabled('server-time')) {
             // Ping to try get a server-time in its response as soon as possible
-            handler.connection.write('PING ' + Date.now());
+            handler.connection.write('PING kiwitime-' + Date.now());
         }
 
         handler.emit('registered', {

--- a/src/commands/handlers/registration.js
+++ b/src/commands/handlers/registration.js
@@ -22,7 +22,7 @@ const handlers = {
         // to an IRC server, not now(). Send a PING so that we can get a reliable time from PONG
         if (handler.network.cap.isEnabled('server-time')) {
             // Ping to try get a server-time in its response as soon as possible
-            handler.connection.write('PING kiwitime-' + Date.now());
+            handler.connection.write('PING ' + Date.now());
         }
 
         handler.emit('registered', {

--- a/test/commands/handlers/misc.test.js
+++ b/test/commands/handlers/misc.test.js
@@ -13,28 +13,21 @@ chai.use(sinonChai);
 
 describe('src/commands/handlers/misc.js', function() {
     describe('PING handler', function() {
+        const mock = mocks.IrcCommandHandler([misc]);
+        const cmd = new IrcCommand('PING', {
+            params: ['example.com'],
+            tags: {
+                time: '2021-06-29T16:42:00Z',
+            }
+        });
+        mock.handlers.PING(cmd, mock.spies);
+
         it('should respond with the appropriate PONG message', function() {
-            const mock = mocks.IrcCommandHandler([misc]);
-            const cmd = new IrcCommand('PING', {
-                params: ['example.com'],
-                tags: {
-                    time: '2021-06-29T16:42:00Z',
-                }
-            });
-            mock.handlers.PING(cmd, mock.spies);
             expect(mock.spies.connection.write).to.have.been.calledOnce;
             expect(mock.spies.connection.write).to.have.been.calledWith('PONG example.com');
         });
 
         it('should emit the appropriate PING event', function() {
-            const mock = mocks.IrcCommandHandler([misc]);
-            const cmd = new IrcCommand('PING', {
-                params: ['one.example.com'],
-                tags: {
-                    time: '2021-06-29T16:42:00Z',
-                }
-            });
-            mock.handlers.PING(cmd, mock.spies);
             expect(mock.spies.emit).to.have.been.calledOnce;
             expect(mock.spies.emit).to.have.been.calledWith('ping', {
                 message: undefined,

--- a/test/commands/handlers/misc.test.js
+++ b/test/commands/handlers/misc.test.js
@@ -5,7 +5,6 @@
 const chai = require('chai');
 const expect = chai.expect;
 const mocks = require('../../mocks');
-const parse = require('../../../src/irclineparser');
 const sinonChai = require('sinon-chai');
 const misc = require('../../../src/commands/handlers/misc');
 const IrcCommand = require('../../../src/commands/command');
@@ -16,9 +15,34 @@ describe('src/commands/handlers/misc.js', function() {
     describe('PING handler', function() {
         it('should respond with the appropriate PONG message', function() {
             const mock = mocks.IrcCommandHandler([misc]);
-            mock.handlers.PING(parse('PING example.com'), mock.spies);
+            const cmd = new IrcCommand('PING', {
+                params: ['example.com'],
+                tags: {
+                    time: '2021-06-29T16:42:00Z',
+                }
+            });
+            mock.handlers.PING(cmd, mock.spies);
             expect(mock.spies.connection.write).to.have.been.calledOnce;
             expect(mock.spies.connection.write).to.have.been.calledWith('PONG example.com');
+        });
+
+        it('should emit the appropriate PING event', function() {
+            const mock = mocks.IrcCommandHandler([misc]);
+            const cmd = new IrcCommand('PING', {
+                params: ['one.example.com'],
+                tags: {
+                    time: '2021-06-29T16:42:00Z',
+                }
+            });
+            mock.handlers.PING(cmd, mock.spies);
+            expect(mock.spies.emit).to.have.been.calledOnce;
+            expect(mock.spies.emit).to.have.been.calledWith('ping', {
+                message: undefined,
+                time: 1624984920000,
+                tags: {
+                    time: '2021-06-29T16:42:00Z'
+                }
+            });
         });
     });
 


### PR DESCRIPTION
This should help with connectivity on mobile browsers that pause setTimeout() events when no longer focused.

It does so by triggering resetPingTimeoutTimer() here:

https://github.com/kiwiirc/irc-framework/blob/a515b1bd3c34aab8f30c6e97c4abb3f0d36dd8bb/src/client.js#L199-L200