### PR TITLE
Normalize channel names in list numerics

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -79,7 +79,7 @@ module.exports = class IrcClient extends EventEmitter {
         client.network = new NetworkInfo();
         client.user = new User();
 
-        client.command_handler = new IrcCommandHandler(client.connection, client.network);
+        client.command_handler = new IrcCommandHandler(client);
 
         client.addCommandHandlerListeners();
 

--- a/src/commands/handler.js
+++ b/src/commands/handler.js
@@ -10,14 +10,15 @@ const irc_numerics = require('./numerics');
 const IrcCommand = require('./command');
 
 module.exports = class IrcCommandHandler extends EventEmitter {
-    constructor(connection, network_info) {
+    constructor(client) {
         super();
 
         // Adds an 'all' event to .emit()
         this.addAllEventName();
 
-        this.connection = connection;
-        this.network = network_info;
+        this.client = client;
+        this.connection = client.connection;
+        this.network = client.network;
         this.handlers = [];
 
         this.request_extra_caps = [];

--- a/src/commands/handlers/channel.js
+++ b/src/commands/handlers/channel.js
@@ -43,7 +43,8 @@ const handlers = {
 
     RPL_NAMEREPLY: function(command, handler) {
         const members = command.params[command.params.length - 1].split(' ');
-        const cache = handler.cache('names.' + command.params[2]);
+        const normalized_channel = handler.client.caseLower(command.params[2]);
+        const cache = handler.cache('names.' + normalized_channel);
 
         if (!cache.members) {
             cache.members = [];
@@ -81,7 +82,8 @@ const handlers = {
     },
 
     RPL_ENDOFNAMES: function(command, handler) {
-        const cache = handler.cache('names.' + command.params[1]);
+        const normalized_channel = handler.client.caseLower(command.params[1]);
+        const cache = handler.cache('names.' + normalized_channel);
         handler.emit('userlist', {
             channel: command.params[1],
             users: cache.members || []
@@ -90,7 +92,8 @@ const handlers = {
     },
 
     RPL_INVITELIST: function(command, handler) {
-        const cache = handler.cache('inviteList.' + command.params[1]);
+        const normalized_channel = handler.client.caseLower(command.params[1]);
+        const cache = handler.cache('inviteList.' + normalized_channel);
         if (!cache.invites) {
             cache.invites = [];
         }
@@ -105,7 +108,8 @@ const handlers = {
     },
 
     RPL_ENDOFINVITELIST: function(command, handler) {
-        const cache = handler.cache('inviteList.' + command.params[1]);
+        const normalized_channel = handler.client.caseLower(command.params[1]);
+        const cache = handler.cache('inviteList.' + normalized_channel);
         handler.emit('inviteList', {
             channel: command.params[1],
             invites: cache.invites || []
@@ -115,7 +119,8 @@ const handlers = {
     },
 
     RPL_BANLIST: function(command, handler) {
-        const cache = handler.cache('banlist.' + command.params[1]);
+        const normalized_channel = handler.client.caseLower(command.params[1]);
+        const cache = handler.cache('banlist.' + normalized_channel);
         if (!cache.bans) {
             cache.bans = [];
         }
@@ -130,7 +135,8 @@ const handlers = {
     },
 
     RPL_ENDOFBANLIST: function(command, handler) {
-        const cache = handler.cache('banlist.' + command.params[1]);
+        const normalized_channel = handler.client.caseLower(command.params[1]);
+        const cache = handler.cache('banlist.' + normalized_channel);
         handler.emit('banlist', {
             channel: command.params[1],
             bans: cache.bans || []

--- a/test/networkinfo.test.js
+++ b/test/networkinfo.test.js
@@ -7,7 +7,7 @@ const NetworkInfo = require('../src/networkinfo');
 const IrcCommandHandler = require('../src/commands/handler');
 
 function newMockClient() {
-    const handler = new IrcCommandHandler(undefined, new NetworkInfo());
+    const handler = new IrcCommandHandler({ network: new NetworkInfo() });
     return handler;
 }
 


### PR DESCRIPTION
Closes https://github.com/thelounge/thelounge/issues/4126

Some servers may not write channel names with consistent casing.
For example, Bahamut writes RPL_NAMREPLY using the real case of the channel,
while RPL_ENDOFNAMES uses the case of the client's command.

For example, when joining a channel named `#ValTest`:

```
C: join #VALtest
S: :val4!~f@lfbn-idf3-1-1313-105.w92-170.abo.wanadoo.fr JOIN :#VALtest
S: :bitcoin.uk.eu.dal.net 353 val4 = #ValTest :val4 val3 @val2 
S: :bitcoin.uk.eu.dal.net 366 val4 #VALtest :End of /NAMES list.
```