### PR TITLE
Store capability values from CAP v3.2 handshakes + honor SASL v3.2 mechanism lists

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -112,6 +112,7 @@ module.exports = class IrcClient extends EventEmitter {
             client.network.cap.negotiating = false;
             client.network.cap.requested = [];
             client.network.cap.enabled = [];
+            client.network.cap.available.clear();
 
             client.command_handler.resetCache();
         });

--- a/src/commands/handlers/registration.js
+++ b/src/commands/handlers/registration.js
@@ -109,6 +109,7 @@ const handlers = {
         const capabilities = command.params[command.params.length - 1]
             .replace(/(?:^| )[-~=]/, '')
             .split(' ')
+            .filter((cap) => !!cap)
             .map(function(cap) {
                 // CAPs in 3.2 may be in the form of CAP=VAL. So seperate those out
                 const sep = cap.indexOf('=');
@@ -199,13 +200,18 @@ const handlers = {
             if (handler.network.cap.negotiating) {
                 let authenticating = false;
                 if (handler.network.cap.isEnabled('sasl')) {
-                    const mechanism = (typeof handler.connection.options.sasl_mechanism === 'string') ? handler.connection.options.sasl_mechanism : 'PLAIN';
+                    const options_mechanism = handler.connection.options.sasl_mechanism;
+                    const wanted_mechanism = (typeof options_mechanism === 'string') ?
+                        options_mechanism.toUpperCase() :
+                        'PLAIN';
+
                     const mechanisms = handler.network.cap.available.get('sasl');
+                    const valid_mechanisms = mechanisms.toUpperCase().split(',');
                     if (
                         !mechanisms || // SASL v3.1
-                        mechanisms.toUpperCase().split(',').includes(mechanism.toUpperCase()) // SASL v3.2
+                        valid_mechanisms.includes(wanted_mechanism) // SASL v3.2
                     ) {
-                        handler.connection.write('AUTHENTICATE ' + mechanism);
+                        handler.connection.write('AUTHENTICATE ' + wanted_mechanism);
                         authenticating = true;
                     }
                 }

--- a/src/commands/handlers/registration.js
+++ b/src/commands/handlers/registration.js
@@ -114,7 +114,7 @@ const handlers = {
                 const sep = cap.indexOf('=');
                 if (sep === -1) {
                     capability_values[cap] = '';
-                    if (command.params[1] === 'LS') {
+                    if (command.params[1] === 'LS' || command.params[1] === 'NEW') {
                         handler.network.cap.available.set(cap, '');
                     }
                     return cap;
@@ -124,7 +124,7 @@ const handlers = {
                 const cap_value = cap.substr(sep + 1);
 
                 capability_values[cap_name] = cap_value;
-                if (command.params[1] === 'LS') {
+                if (command.params[1] === 'LS' || command.params[1] === 'NEW') {
                     handler.network.cap.available.set(cap_name, cap_value);
                 }
                 return cap_name;
@@ -256,6 +256,9 @@ const handlers = {
                 handler.network.cap.enabled,
                 capabilities
             );
+            for (const cap_name of capabilities) {
+                handler.network.cap.available.delete(cap_name);
+            }
             break;
         }
 

--- a/src/commands/handlers/registration.js
+++ b/src/commands/handlers/registration.js
@@ -114,6 +114,9 @@ const handlers = {
                 const sep = cap.indexOf('=');
                 if (sep === -1) {
                     capability_values[cap] = '';
+                    if (command.params[1] === 'LS') {
+                        handler.network.cap.available.set(cap, '');
+                    }
                     return cap;
                 }
 
@@ -121,6 +124,9 @@ const handlers = {
                 const cap_value = cap.substr(sep + 1);
 
                 capability_values[cap_name] = cap_value;
+                if (command.params[1] === 'LS') {
+                    handler.network.cap.available.set(cap_name, cap_value);
+                }
                 return cap_name;
             });
 
@@ -249,7 +255,7 @@ const handlers = {
 
         handler.emit('cap ' + command.params[1].toLowerCase(), {
             command: command.params[1],
-            capabilities: capability_values,
+            capabilities: capability_values, // for backward-compatibility
         });
     },
 

--- a/src/networkinfo.js
+++ b/src/networkinfo.js
@@ -108,6 +108,7 @@ function NetworkInfo() {
         negotiating: false,
         requested: [],
         enabled: [],
+        available: new Map(),
         isEnabled: function(cap_name) {
             return this.enabled.indexOf(cap_name) > -1;
         }


### PR DESCRIPTION
1. Store capability values in 'CAP LS 302' negotiations.
    
    So it can be retrieved later (eg. to know what SASL mechanisms are available).
    
    https://ircv3.net/specs/extensions/capability-negotiation.html#the-cap-ls-subcommand


2. Honor SASL v3.2 mechanism lists
    
    From https://ircv3.net/specs/extensions/sasl-3.2#usage:
    
    > Clients SHOULD pick a mechanism present in the CAP LS reply they get from the server and attempt to use that mechanism for authentication after they request the sasl capability.

Tested on The Lounge.