### PR TITLE
generics: add ERR_NOSUCHSERVER

### DIFF
--- a/src/commands/handlers/generics.js
+++ b/src/commands/handlers/generics.js
@@ -36,6 +36,13 @@ const generics = {
         reason: -1
     },
 
+    ERR_NOSUCHSERVER: {
+        event: 'irc error',
+        error: 'no_such_server',
+        server: 1,
+        reason: -1
+    },
+
     ERR_CANNOTSENDTOCHAN: {
         event: 'irc error',
         error: 'cannot_send_to_channel',


### PR DESCRIPTION
The error gets emitted for a few events, whois among them
when a two value WHOIS is sent but the nick is invalid.