### PR TITLE
Clear enabled caps array on connection

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -111,6 +111,7 @@ module.exports = class IrcClient extends EventEmitter {
             // This prevents stale state if a connection gets closed during CAP negotiation
             client.network.cap.negotiating = false;
             client.network.cap.requested = [];
+            client.network.cap.enabled = [];
 
             client.command_handler.resetCache();
         });


### PR DESCRIPTION
The server might have changed available caps or the client may request different caps since last connection, make sure we do not have stale list of enabled caps.

I found this issue by trying to connect with sasl and invalid password, then trying to connect without sasl. due to the sasl being negotiated on the first connect it was still in the enabled state on the second attempt even though it was not required, causing a connection timeout