### PR TITLE
feat: support CLIENTTAGDENY

### DIFF
--- a/src/commands/handlers/registration.js
+++ b/src/commands/handlers/registration.js
@@ -84,6 +84,9 @@ const handlers = {
                 handler.network.options.CHANMODES = option[1].split(',');
             } else if (option[0] === 'CASEMAPPING') {
                 handler.network.options.CASEMAPPING = option[1];
+            // https://ircv3.net/specs/extensions/message-tags#rpl_isupport-tokens
+            } else if (option[0] === 'CLIENTTAGDENY' && handler.network.cap.isEnabled('message-tags')) {
+                handler.network.options.CLIENTTAGDENY = option[1].split(',');
             } else if (option[0] === 'NETWORK') {
                 handler.network.name = option[1];
             } else if (option[0] === 'NAMESX' && !handler.network.cap.isEnabled('multi-prefix')) {

--- a/src/networkinfo.js
+++ b/src/networkinfo.js
@@ -25,7 +25,8 @@ function NetworkInfo() {
             { symbol: '@', mode: 'o' },
             { symbol: '%', mode: 'h' },
             { symbol: '+', mode: 'v' }
-        ]
+        ],
+        CLIENTTAGDENY: []
     };
 
     this.time_offsets = [];

--- a/test/messagetags.js
+++ b/test/messagetags.js
@@ -8,6 +8,49 @@ const assert = chai.assert;
 chai.use(require('chai-subset'));
 
 describe('src/messagetags.js', function() {
+    describe('CLIENTTAGDENY= parsing', function() {
+        it('should parse CLIENTTAGDENY=', function() {
+            assert.deepEqual(MessageTags.parseDenylist(''), {
+                allBlockedByDefault: false,
+                explicitlyDenied: [],
+                explicitlyAccepted: []
+            });
+        });
+
+        it('should parse CLIENTTAGDENY=*,-a', function() {
+            assert.deepEqual(MessageTags.parseDenylist('*,-a'), {
+                allBlockedByDefault: true,
+                explicitlyAccepted: ['a'],
+                explicitlyDenied: []
+            });
+        });
+
+        it('should parse CLIENTTAGDENY=a,b', function() {
+            assert.deepEqual(MessageTags.parseDenylist('a,b'), {
+                allBlockedByDefault: false,
+                explicitlyAccepted: [],
+                explicitlyDenied: ['a', 'b']
+            });
+        });
+    });
+
+    describe('CLIENTTAGDENY= logic', function() {
+        it('should block all tags (`b`) with * and no exception', function() {
+            assert.isTrue(MessageTags.isBlocked(MessageTags.parseDenylist('*'), 'b'));
+        });
+
+        it('should not block all tags with * and exceptions (`c`, `a`)', function() {
+            assert.isFalse(MessageTags.isBlocked(MessageTags.parseDenylist('*,-c,-a'), 'a'));
+            assert.isFalse(MessageTags.isBlocked(MessageTags.parseDenylist('*,-c,-a'), 'c'));
+            assert.isTrue(MessageTags.isBlocked(MessageTags.parseDenylist('*,-c,-a'), 'b'));
+        });
+
+        it('should block a specific tag if no * is present', function() {
+            assert.isTrue(MessageTags.isBlocked(MessageTags.parseDenylist('a'), 'a'));
+            assert.isFalse(MessageTags.isBlocked(MessageTags.parseDenylist('a'), 'b'));
+        });
+    });
+
     describe('value encoding', function() {
         it('should decode characters to correct strings', function() {
             const plain = "Some people use IRC; others don't \\o/ Note: Use IRC\r\n";

--- a/test/networkinfo.test.js
+++ b/test/networkinfo.test.js
@@ -53,5 +53,35 @@ describe('src/networkinfo.js', function() {
             const results = names.map(name => client.network.isChannelName(name));
             assert.deepEqual(results, [false, false, false, false, false, false]);
         });
+
+        it('should parse CLIENTTAGDENY= as a list', function() {
+            const client = newMockClient();
+            client.dispatch({
+                command: '005',
+                params: ['nick', 'CLIENTTAGDENY='],
+                tags: []
+            });
+            assert.isEmpty(client.network.options.CLIENTTAGDENY);
+        });
+
+        it('should parse CLIENTTAGDENY=*,-a,-b as a list', function() {
+            const client = newMockClient();
+            client.dispatch({
+                command: '005',
+                params: ['nick', 'CLIENTTAGDENY=*,-a,-b'],
+                tags: []
+            });
+            assert.equal(client.network.options.CLIENTTAGDENY, ['*', '-a', '-b']);
+        });
+    });
+
+    it('should parse CLIENTTAGDENY=a,b,c as a list', function() {
+        const client = newMockClient();
+        client.dispatch({
+            command: '005',
+            params: ['nick', 'CLIENTTAGDENY=a,b,c'],
+            tags: []
+        });
+        assert.equal(client.network.options.CLIENTTAGDENY, ['a', 'b', 'c']);
     });
 });


### PR DESCRIPTION
This is useful for clients which want to do graceful degradations of client tags features such as typing, reacts, replies, etc.

See https://ircv3.net/specs/extensions/message-tags#rpl_isupport-tokens for specification.