### PR TITLE
Remove misleading comment

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -161,7 +161,6 @@ module.exports = class Connection extends EventEmitter {
 
         const message = ircLineParser(line);
         if (!message) {
-            // A malformed IRC line
             return;
         }
 


### PR DESCRIPTION
The comment falsely indicates that malformed IRC messages would be null.

However, since the switch to a proper parser the function always returns an IrcMessage object, no matter how broken the input is.

```
const parser = require('./src/irclineparser');
console.log(parser('\0'));

// IrcMessage {
//   tags: [Object: null prototype] {},
//   prefix: '',
//   nick: '',
//   ident: '',
//   hostname: '',
//   command: '\x00',
//   params: []
// }
```

Hence, remove the comment to avoid misleading readers but keep the guard, should the parser change in the future.