### PR TITLE
whowas: return all responses from the server

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -596,6 +596,10 @@ Not all of these options will be available. Some will be missing depending on th
 
 **whowas**
 
+The response includes the latest known data.
+If more than one RPL_WHOWASUSER is returned by the server, older ones
+are stored in the same format in the 'historical' array from newest to oldest.
+
 If the requested user was not found, error will contain 'no_such_nick'.
 ~~~javascript
 {
@@ -609,6 +613,10 @@ If the requested user was not found, error will contain 'no_such_nick'.
     server_info: 'Thu Jun 14 09:15:51 2018',
     account: 'logged on account',
     error: ''
+    historical: [
+        { ... },
+        { ... },
+    ]
 }
 ~~~
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -596,11 +596,13 @@ Not all of these options will be available. Some will be missing depending on th
 
 **whowas**
 
-The response includes the latest known data.
-If more than one RPL_WHOWASUSER is returned by the server, older ones
-are stored in the same format in the 'historical' array from newest to oldest.
+The response root includes the latest data `historical[0]` to maintain backwards compatibility.
+The `historical` array contains all RPL_WHOWASUSER responses with the newest being first.
 
-If the requested user was not found, error will contain 'no_such_nick'.
+If the requested user was not found, `error` will contain 'no_such_nick'.
+
+> Note: The available data can vary depending on the network.
+
 ~~~javascript
 {
     nick: 'prawnsalad',
@@ -608,6 +610,7 @@ If the requested user was not found, error will contain 'no_such_nick'.
     hostname: 'manchester.isp.net',
     actual_ip: 'sometimes set when using webirc, could be the same as actual_hostname',
     actual_hostname: 'sometimes set when using webirc',
+    actual_username: 'prawn',
     real_name: 'A real prawn',
     server: 'irc.server.net',
     server_info: 'Thu Jun 14 09:15:51 2018',

--- a/docs/events.md
+++ b/docs/events.md
@@ -596,8 +596,8 @@ Not all of these options will be available. Some will be missing depending on th
 
 **whowas**
 
-The response root includes the latest data `historical[0]` to maintain backwards compatibility.
-The `historical` array contains all RPL_WHOWASUSER responses with the newest being first.
+The response root includes the latest data from `whowas[0]` to maintain backwards compatibility.
+The `whowas` array contains all RPL_WHOWASUSER responses with the newest being first.
 
 If the requested user was not found, `error` will contain 'no_such_nick'.
 
@@ -616,7 +616,7 @@ If the requested user was not found, `error` will contain 'no_such_nick'.
     server_info: 'Thu Jun 14 09:15:51 2018',
     account: 'logged on account',
     error: ''
-    historical: [
+    whowas: [
         { ... },
         { ... },
     ]

--- a/src/commands/handlers/user.js
+++ b/src/commands/handlers/user.js
@@ -362,8 +362,8 @@ const handlers = {
         const host = user_host.substring(mask_sep + 1);
 
         if (host) {
-            cache.actual_user = user;
-            cache.actual_host = host;
+            cache.actual_username = user;
+            cache.actual_username = host;
         }
     },
 
@@ -391,12 +391,6 @@ const handlers = {
         // now pull the newest response to the top level and add the rest as an array
         const event = _.cloneDeep(whowas_cache.historical[0]);
         event.historical = whowas_cache.historical;
-
-        // Should, in theory, never happen.
-        if (!event.nick) {
-            event.nick = command.params[1];
-            event.error = 'no_such_nick';
-        }
 
         handler.emit('whowas', event);
         whois_cache.destroy();

--- a/src/commands/handlers/user.js
+++ b/src/commands/handlers/user.js
@@ -3,7 +3,6 @@
 const _ = {
     each: require('lodash/each'),
     map: require('lodash/map'),
-    cloneDeep: require('lodash/cloneDeep'),
 };
 const Helpers = require('../../helpers');
 
@@ -339,7 +338,7 @@ const handlers = {
             whowas_cache.whowas = [];
         } else {
             // push the previous event prior to modifying anything
-            whowas_cache.whowas.push(_.cloneDeep(whois_cache));
+            whowas_cache.whowas.push(whois_cache);
             // ensure we are starting with a clean cache for the next data
             whois_cache.destroy();
             whois_cache = handler.cache('whois.' + cache_key);
@@ -369,10 +368,10 @@ const handlers = {
         // push the last one to complete the set (server returns from newest to oldest)
         whowas_cache.whowas = whowas_cache.whowas || [];
         if (!whois_cache.error) {
-            whowas_cache.whowas.push(_.cloneDeep(whois_cache));
-            Object.assign(whowas_cache, _.cloneDeep(whowas_cache.whowas[0]));
+            whowas_cache.whowas.push(whois_cache);
+            Object.assign(whowas_cache, whowas_cache.whowas[0]);
         } else {
-            Object.assign(whowas_cache, _.cloneDeep(whois_cache));
+            Object.assign(whowas_cache, whois_cache);
         }
 
         handler.emit('whowas', whowas_cache);

--- a/src/commands/handlers/user.js
+++ b/src/commands/handlers/user.js
@@ -367,8 +367,8 @@ const handlers = {
 
         // after all prior RPL_WHOWASUSER pushed newer events onto the history stack
         // push the last one to complete the set (server returns from newest to oldest)
+        whowas_cache.whowas = whowas_cache.whowas || [];
         if (!whois_cache.error) {
-            whowas_cache.whowas = whowas_cache.whowas || [];
             whowas_cache.whowas.push(_.cloneDeep(whois_cache));
             Object.assign(whowas_cache, _.cloneDeep(whowas_cache.whowas[0]));
         } else {

--- a/src/commands/numerics.js
+++ b/src/commands/numerics.js
@@ -153,6 +153,7 @@ module.exports = {
     '531': 'ERR_CANNOTSENDTOUSER',
     /* InspIRCD specific https://github.com/inspircd/inspircd-contrib/blob/master/3.0/m_asn.cpp */
     '569': 'RPL_WHOISASN',
+    '652': 'RPL_WHOWASIP',
     '670': 'RPL_STARTTLS',
     '671': 'RPL_WHOISSECURE',
     '704': 'RPL_HELPSTART',

--- a/src/commands/numerics.js
+++ b/src/commands/numerics.js
@@ -153,7 +153,6 @@ module.exports = {
     '531': 'ERR_CANNOTSENDTOUSER',
     /* InspIRCD specific https://github.com/inspircd/inspircd-contrib/blob/master/3.0/m_asn.cpp */
     '569': 'RPL_WHOISASN',
-    '652': 'RPL_WHOWASIP',
     '670': 'RPL_STARTTLS',
     '671': 'RPL_WHOISSECURE',
     '704': 'RPL_HELPSTART',


### PR DESCRIPTION
Whowas results are a list of all known RPL_WHOWASUSER replies. Return the most recent event as the top level and add the rest to a `historical` field as an array.

Example:

```
:inspircd.server.example 314 val someone ident3 127.0.0.1 * :Realname
:inspircd.server.example 312 val someone My.Little.Server :Sun Mar 20 2022 10:59:26
:inspircd.server.example 314 val someone ident2 127.0.0.1 * :Realname
:inspircd.server.example 312 val someone My.Little.Server :Sun Mar 20 2022 10:59:16
:inspircd.server.example 314 val someone ident1 127.0.0.1 * :Realname
:inspircd.server.example 312 val someone My.Little.Server :Sun Mar 19 2022 9:23:06
:inspircd.server.example 369 val someone :End of WHOWAS

whowas {
  nick: 'someone',
  ident: 'ident3',
  hostname: '127.0.0.1',
  real_name: 'Realname',
  server: 'My.Little.Server',
  server_info: 'Sun Mar 20 2022 10:59:26',
  historical: [
    {
      nick: 'someone',
      ident: 'ident2',
      hostname: '127.0.0.1',
      real_name: 'Realname',
      server: 'My.Little.Server',
      server_info: 'Sun Mar 20 2022 10:59:16'
    },
    {
      nick: 'someone',
      ident: 'ident1',
      hostname: '127.0.0.1',
      real_name: 'Realname',
      server: 'My.Little.Server',
      server_info: 'Sun Mar 19 2022 9:23:06'
    }
  ]
}
```

Fixes: https://github.com/kiwiirc/irc-framework/issues/371