### PR TITLE
Fix retrieving multiple certificate fingerprints on InspIRCd v4.

### DIFF
--- a/src/commands/handlers/user.js
+++ b/src/commands/handlers/user.js
@@ -272,8 +272,10 @@ const handlers = {
     RPL_WHOISCERTFP: function(command, handler) {
         const cache_key = command.params[1].toLowerCase();
         const cache = handler.cache('whois.' + cache_key);
-        cache.certfp = cache.certfp || [];
-        cache.certfp.push(command.params[command.params.length - 1]);
+        const certfp = command.params[command.params.length - 1];
+        cache.certfp = cache.certfp || certfp;
+        cache.certfps = cache.certfps || [];
+        cache.certfps.push(certfp);
     },
 
     RPL_WHOISACCOUNT: function(command, handler) {

--- a/src/commands/handlers/user.js
+++ b/src/commands/handlers/user.js
@@ -272,7 +272,8 @@ const handlers = {
     RPL_WHOISCERTFP: function(command, handler) {
         const cache_key = command.params[1].toLowerCase();
         const cache = handler.cache('whois.' + cache_key);
-        cache.certfp = command.params[command.params.length - 1];
+        cache.certfp = cache.certfp || [];
+        cache.certfp.push(command.params[command.params.length - 1]);
     },
 
     RPL_WHOISACCOUNT: function(command, handler) {


### PR DESCRIPTION
InspIRCd v4 supports using multiple TLS fingerprint algorithms to allow upgrading from insecure algorithms over time. We expose this to clients by sending multiple `RPL_WHOISCERTFP` lines. 

Unfortunately, irc-framework only caches the last of these to users which breaks WHOIS output on The Lounge as the last one on multiple-fingerprint networks is always a fallback. This has resulted in confused users who are unsure why their client is showing a different fingerprint to services. 

This PR fixes that by caching the multiple fingerprint algorithms sent by the IRC server.