### PR TITLE
Fix RPL_LOGGEDIN Prematurely Triggering CAP END

### DIFF
--- a/src/commands/handlers/registration.js
+++ b/src/commands/handlers/registration.js
@@ -323,11 +323,6 @@ const handlers = {
     },
 
     RPL_LOGGEDIN: function(command, handler) {
-        if (handler.network.cap.negotiating === true) {
-            handler.connection.write('CAP END');
-            handler.network.cap.negotiating = false;
-        }
-
         const mask = Helpers.parseMask(command.params[1]);
 
         // Check if we have a server-time


### PR DESCRIPTION
This will fix Issue #390.

The bug is that per the SASL [spec](https://ircv3.net/specs/extensions/sasl-3.1#:~:text=To%20enforce%20the%20former%2C%20it%20is%20RECOMMENDED%20to%20only%20send%20CAP%20END%20when%20the%20SASL%20exchange%20is%20completed%20or%20needs%20to%20be%20aborted), sending CAP END before the IRCd has finalized your SASL authentication is treated as a SASL Abort and the authentication will fail. The 900 (RPL_LOGGEDIN numeric does not necessarily mean the IRCd has completely finished handling the SASL, and therefore, sending CAP END upon the receipt of RPL_LOGGEDIN can trigger a race condition where SASL authentication will fail.

This was observed after much frustration trying to code a bot that was attempting to SASL PLAIN on a nefarious2 IRCd and I noticed that when I installed breakpoints around the SASL AUTHENTICATE commands, it seemed to work fine, but reverted to not working upon removing said breakpoints.

The solution is to simply remove the CAP END's parent IF block in the **RPL_LOGGEDIN** handler. Upon testing, the race condition has seemingly been removed.

All unit tests continue to pass with this change.