### PR TITLE
add missing message_max_length to doc

### DIFF
--- a/docs/clientapi.md
+++ b/docs/clientapi.md
@@ -17,6 +17,7 @@ new Irc.Client({
     auto_reconnect_max_retries: 3,
     ping_interval: 30,
     ping_timeout: 120,
+    message_max_length: 350,
     sasl_disconnect_on_fail: false,
     account: {
         account: 'username',


### PR DESCRIPTION
from https://github.com/kiwiirc/irc-framework/blob/0a8d6a6a8f5dc096c14d014963a88f5d0ab3eaec/src/client.js#L56