### PR TITLE
workflows: drop old node, add 24.x, only lint once

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
         run: yarn lint
 
   test:
+    needs: lint
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,13 +3,30 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
-  build:
+  lint:
+    runs-on: ubuntu-latest
 
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile --non-interactive --prefer-offline
+
+      - name: Lint
+        run: yarn lint
+
+  test:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -24,7 +41,4 @@ jobs:
         run: yarn --frozen-lockfile --non-interactive --prefer-offline
 
       - name: Test
-        run: yarn test
-
-      - name: Lint
-        run: yarn lint
+        run: yarn coverage


### PR DESCRIPTION
- Dropped Node 16.x and 18.x, added 24.x           
- Split into two jobs: lint (runs once on Node 22) and test. before we were running lint on every version                       
- Test job runs mocha + nyc directly nstead of also running lint
                