### PR TITLE
Allow passing message tags in action(target, message, tags)

### DIFF
--- a/docs/clientapi.md
+++ b/docs/clientapi.md
@@ -122,8 +122,8 @@ Send a CTCP request to target with any number of parameters.
 ##### `.ctcpResponse(target, type [, paramN])`
 Send a CTCP response to target with any number of parameters.
 
-##### `.action(target, message)`
-Send an action message (typically /me) to a target.
+##### `.action(target, message [, tags])`
+Send an action message (typically /me) to a target, optionally with tags.
 
 ##### `.whois(nick [, cb])`
 Receive information about a user on the network if they exist. Optionally calls

--- a/src/client.js
+++ b/src/client.js
@@ -662,7 +662,7 @@ module.exports = class IrcClient extends EventEmitter {
         );
     }
 
-    action(target, message) {
+    action(target, message, tags) {
         const that = this;
 
         // Maximum length of target + message we can send to the IRC server is 500 characters
@@ -677,7 +677,14 @@ module.exports = class IrcClient extends EventEmitter {
         const blocks = [...lineBreak(message, { bytes: blockLength, allowBreakingWords: true, allowBreakingGraphemes: true })];
 
         blocks.forEach(function(block) {
-            that.ctcpRequest(target, commandName, block);
+            const ctcpBody = String.fromCharCode(1) + commandName + ' ' + block + String.fromCharCode(1);
+            if (tags && Object.keys(tags).length) {
+                const msg = new IrcMessage('PRIVMSG', target, ctcpBody);
+                msg.tags = tags;
+                that.raw(msg);
+            } else {
+                that.ctcpRequest(target, commandName, block);
+            }
         });
 
         return blocks;


### PR DESCRIPTION
Ran into this while adding support for `+reply` to thelounge