### PR TITLE
fix: retry on first connection failure and on failed IRC registration

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -15,7 +15,7 @@ module.exports = class Connection extends EventEmitter {
         this.connected = false;
         this.requested_disconnect = false;
 
-        this.reconnect_attempts = 0;
+        this.reconnect_attempts = 1;
 
         // When an IRC connection was successfully registered.
         this.registered = false;
@@ -31,6 +31,7 @@ module.exports = class Connection extends EventEmitter {
 
     registeredSuccessfully() {
         this.registered = Date.now();
+        this.reconnect_attempts = 1;
     }
 
     connect(options) {
@@ -83,7 +84,6 @@ module.exports = class Connection extends EventEmitter {
         // Called when the socket is connected and ready to start sending/receiving data.
         function socketOpen() {
             that.debugOut('Socket fully connected');
-            that.reconnect_attempts = 0;
             that.connected = true;
             that.emit('socket connected');
         }


### PR DESCRIPTION
## Problem

When an IRC connection fails for the first time (DNS not yet ready, transient network error, ECONNRESET during registration), The Lounge shows:

```
Disconnected from the network, and will not reconnect. Use /connect to reconnect again.
```

Even though `auto_reconnect` is enabled and `auto_reconnect_max_retries` is set to a high value (e.g. 30 in The Lounge). This has been reported in several places:

- thelounge/thelounge#4103 — ECONNRESET with no retries
- thelounge/thelounge#3419 — stops reconnecting after registration errors
- This issue (#211) — original root cause discussion

## Root cause

The reconnect decision in `socketClose` is:

```js
} else if (that.reconnect_attempts && that.reconnect_attempts < that.auto_reconnect_max_retries) {
    should_reconnect = true;

// If we were originally connected OK, reconnect
} else if (was_connected && safely_registered) {
    should_reconnect = true;
} else {
    should_reconnect = false;
}
```

**Bug 1 — initial value:** `reconnect_attempts` is initialised to `0`. Since `0` is falsy in JavaScript, the first branch never fires on a first-ever connection failure. `was_connected` is also false, so the second branch doesn't fire either. Result: the very first failure gives up immediately, no matter how high `max_retries` is.

**Bug 2 — premature reset:** `reconnect_attempts` is reset to `0` inside `socketOpen` (raw TCP connect). This means a connection that reached the TCP layer but failed IRC registration (auth timeout, server-side `ECONNRESET` during NICK/USER, netsplit during connect) will reset the counter on the *next* attempt's TCP connect, effectively giving only one IRC-level retry before exhausting the counter.

Both bugs can be observed in the log pattern from #4103:

```
Reconnecting in 11 seconds… (Attempt 4)   ← TCP connects
Connected to the network.                  ← socketOpen fires, resets counter to 0
-server- *** Found your hostname
Connection closed unexpectedly: ECONNRESET ← socketClose fires, reconnect_attempts == 0 → give up
Disconnected from the network, and will not reconnect.
```

## Fix

Three minimal changes, first proposed by @mornfall in this issue:

1. **Initialise `reconnect_attempts` to `1`** — the first failure now satisfies `reconnect_attempts > 0 && reconnect_attempts < max_retries`, triggering a retry.

2. **Remove the reset from `socketOpen`** — a raw TCP connection is not a successful IRC session. The counter should not reset until IRC registration completes.

3. **Reset to `1` in `registeredSuccessfully`** — after a fully successful registration, the counter resets so the next connection problem gets a fresh set of retries.

## Validation

@mornfall has been running this exact fix in production for **2+ years** with **~100 users** without issues (last comment in this thread). The fix has also been independently validated by @tokariu.

## Diff

```diff
-        this.reconnect_attempts = 0;
+        this.reconnect_attempts = 1;

     registeredSuccessfully() {
         this.registered = Date.now();
+        this.reconnect_attempts = 1;
     }

     function socketOpen() {
         that.debugOut('Socket fully connected');
-        that.reconnect_attempts = 0;
         that.connected = true;
```