### PR TITLE
Fix parsing RPL_WHOISACTUALLY on some networks.

### DIFF
--- a/src/commands/handlers/user.js
+++ b/src/commands/handlers/user.js
@@ -310,19 +310,23 @@ const handlers = {
         const cache_key = command.params[1].toLowerCase();
         const cache = handler.cache('whois.' + cache_key);
 
-        // <source> 338 <target> <nick> [<user>@]<host> <ip> :Actual user@host, Actual IP
-        const user_host = command.params[command.params.length - 3] || '';
-        const mask_sep = user_host.indexOf('@');
-        const user = user_host.substring(0, mask_sep) || undefined;
-        const host = user_host.substring(mask_sep + 1);
-        const ip = command.params[command.params.length - 2];
+        // Until 2018 (commit 5044013) UnrealIRCd used to use this numeric for
+        // RPL_IRCOPS. If there's not enough parameters for it to be the numeric
+        // we expect then just ignore it.
+        if (command.params.length < 4) {
+            return;
+        }
 
-        // UnrealIRCd uses this numeric for something else resulting in ip+host
-        // to be empty, so ignore this is that's the case
-        if (ip && host) {
-            cache.actual_ip = ip;
-            cache.actual_username = user;
-            cache.actual_hostname = host;
+        // <source> 338 <target> <nick> [[<user>@]<host>] <ip> :Actual user@host, Actual IP
+        cache.actual_ip = command.params[command.params.length - 2];
+
+        // Some servers (e.g. Libera.Chat) only return an actual IP address.
+        if (command.params.length > 4) {
+            const user_host = command.params[command.params.length - 3];
+            const mask_sep = user_host.indexOf('@');
+
+            cache.actual_username = user_host.substring(0, mask_sep) || undefined;
+            cache.actual_hostname = user_host.substring(mask_sep + 1);
         }
     },
 


### PR DESCRIPTION
Libera.Chat only sends an IP address and no hostname in this numeric. UnrealIRCd has also fixed their numeric reuse so I've updated the comment to reflect that.

Currently there are three valid forms of the numeric and all of these should now be supported:

1. `<source> 338 <target> <nick> <user>@<host> <ip> :Actual user@host, Actual IP`
2. `<source> 338 <target> <nick> <host> <ip> :Actual user@host, Actual IP`
3. `<source> 338 <target> <nick> <ip> :Actual IP`

Tested using my fork of The Lounge.

---

Note: Event handlers in irc-fw are not particularly robust to unexpected behaviour from servers and it'd probably be good to have a method for command parameter validation that could check the parameter count and then on error dispatch to an common error event and throw something handleable by `executeCommand`. I can submit a pull request for this if you're interested.